### PR TITLE
Kinesiology Page Footer About Us

### DIFF
--- a/elements-testimonials.html
+++ b/elements-testimonials.html
@@ -348,7 +348,7 @@
                                             <h3>ABOUT US</h3>
                                         </div>
                                         <div class="widget-about-content">
-                                            <p>We have a society of wise volunteers who puzzled enigmas or discover inventories. </p>
+                                            <p>An independent non-profit organization, leveraging machine learning & data science. </p>
                                         </div>
                                         <div class="widget-contact-content">
                                             <h3>CONTACT US</h3>


### PR DESCRIPTION
I have changed the English About Us because It's different from other pages.
![image](https://user-images.githubusercontent.com/117187551/204567914-26b0be50-80d3-45ba-abf7-5bd8fb8b3b5b.png)

Every page has below About Us that I am proposing
![image](https://user-images.githubusercontent.com/117187551/204568094-d8baae2a-fe5b-4cb1-bd2d-9a9f37ea2d3b.png)
