### PR TITLE
feat(nav): 2026 accessible navigation overhaul (site-wide)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,10 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -82,10 +76,12 @@
         <!-- master CSS
         ============================================ -->
         <link rel="stylesheet" href="master.css">
-
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!--[if lt IE 8]>
@@ -104,38 +100,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-		                                    </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="index.html">
-                                        <img src="img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="sciences/agriculture/">Agriculture</a></li>
@@ -172,132 +208,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="technology/data-science/">Data Science</a></li>
                                                     <li><a href="technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="research/innovation/">Innovation</a></li>
-                                                    <li><a href="research/our-process/">Our Process</a></li>
-                                                    <li><a href="research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="research/facilities/">Facilities</a></li>
-                                                    <li><a href="research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="community/contact/">Contact</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/about.html
+++ b/about.html
@@ -1,10 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -34,10 +28,12 @@
         <!-- master CSS
         ============================================ -->            
         <link rel="stylesheet" href="master.css">
-		
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-
-        <style>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+<style>
             /* Mission charter blockquote — About page */
             .about-mission-block {
                 margin: 22px 0 26px;
@@ -90,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-		                                    </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="index.html">
-                                        <img src="img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="sciences/agriculture/">Agriculture</a></li>
@@ -158,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="technology/data-science/">Data Science</a></li>
                                                     <li><a href="technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="research/innovation/">Innovation</a></li>
-                                                    <li><a href="research/our-process/">Our Process</a></li>
-                                                    <li><a href="research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="research/facilities/">Facilities</a></li>
-                                                    <li><a href="research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="community/contact/">Contact</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main>

--- a/accessibility.html
+++ b/accessibility.html
@@ -1,10 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -80,9 +74,12 @@
 
         <!-- master CSS -->
         <link rel="stylesheet" href="master.css">
-
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!--[if lt IE 8]>
@@ -101,37 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="index.html">
-                                        <img src="img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="sciences/agriculture/">Agriculture</a></li>
@@ -168,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="technology/data-science/">Data Science</a></li>
                                                     <li><a href="technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="research/innovation/">Innovation</a></li>
-                                                    <li><a href="research/our-process/">Our Process</a></li>
-                                                    <li><a href="research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="research/facilities/">Facilities</a></li>
-                                                    <li><a href="research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="community/contact/">Contact</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/community/about-us/index.html
+++ b/community/about-us/index.html
@@ -75,8 +75,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -91,38 +95,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/" aria-current="page">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -159,133 +203,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#" aria-current="page">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
-                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/" aria-current="page">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/community/careers/index.html
+++ b/community/careers/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -80,38 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -148,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#" aria-current="page">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
+                                                    <li><a href="../../community/careers/" aria-current="page">Careers</a></li>
                                                     <li><a href="../../community/contact/">Contact</a></li>
-                                                    <li><a href="../../community/careers/">Careers</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/" aria-current="page">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/community/contact/index.html
+++ b/community/contact/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!-- Start main area -->
@@ -80,37 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -147,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#" aria-current="page">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/" aria-current="page">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/" aria-current="page">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/community/leadership/index.html
+++ b/community/leadership/index.html
@@ -75,8 +75,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -91,38 +95,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/" aria-current="page">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -159,134 +203,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#" aria-current="page">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
-                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/leadership/">Leadership</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/" aria-current="page">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/community/partner/index.html
+++ b/community/partner/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -80,38 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -148,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#" aria-current="page">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/partner/">Partner</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/partner/">Partner</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/partner/">Partner</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/community/support/index.html
+++ b/community/support/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!-- Start main area -->
@@ -80,37 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -147,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#" aria-current="page">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/community/work-with-us/index.html
+++ b/community/work-with-us/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -80,38 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -148,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#" aria-current="page">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/" aria-current="page">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/" aria-current="page">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/contact-us.html
+++ b/contact-us.html
@@ -1,10 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -34,12 +28,12 @@
         <!-- master CSS
         ============================================ -->            
         <link rel="stylesheet" href="master.css">
-		
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-
-       
-
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <!--[if lt IE 8]>
             <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
@@ -57,38 +51,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-		                                    </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="index.html">
-                                        <img src="img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="sciences/agriculture/">Agriculture</a></li>
@@ -125,132 +159,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="technology/data-science/">Data Science</a></li>
                                                     <li><a href="technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="research/innovation/">Innovation</a></li>
-                                                    <li><a href="research/our-process/">Our Process</a></li>
-                                                    <li><a href="research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="research/facilities/">Facilities</a></li>
-                                                    <li><a href="research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="community/contact/">Contact</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main>

--- a/css/nav-2026.css
+++ b/css/nav-2026.css
@@ -1,0 +1,479 @@
+/* ==========================================================================
+   nav-2026.css — INSTAR Lab 2026 Navigation Upgrade
+   Shared stylesheet loaded after master.css to override legacy nav styles.
+   Companion script: js/nav-2026.js
+   ========================================================================== */
+
+/* ------------------------------------------------------------------
+   MEGA-MENU POSITIONING FIX
+   .mega-menu-area is position:absolute. The nearest positioned
+   ancestor is .main-area {position:relative}, whose height spans
+   the full page. Fix: add position:relative to #sticker (the
+   nav-bar container) whenever it is NOT in sticky mode, making
+   top:100% resolve to just below the nav bar.
+   The :not(.stick) guard ensures this doesn't fire in sticky mode
+   (where main.js adds class .stick and position:fixed takes over).
+   ------------------------------------------------------------------ */
+#sticker:not(.stick) {
+  position: relative;
+}
+
+/* ------------------------------------------------------------------
+   NAV RIGHT-SHIFT — push menu items toward the Donate CTA
+   donate-button is rendered before main-menu in the HTML so its
+   float:right occupies the far-right slot first. Floating the nav
+   <ul> right lands it immediately to the left of the Donate button.
+   li items still float:left (existing rule), preserving L→R order.
+   Responsive safety: responsive.css hides .main-menu below 768px.
+   ------------------------------------------------------------------ */
+.main-menu-area .main-menu nav > ul {
+  float: right;
+}
+
+/* ========================================================================
+   nav2026 — SOTA Disclosure Nav + WCAG 2.2 AA Mobile Drawer
+   ======================================================================== */
+
+/* ---- Design tokens ---- */
+:root {
+  --n-brand:   #1072ba;
+  --n-deep:    #1d4ed8;
+  --n-text:    #444;
+  --n-font:    "Raleway", sans-serif;
+  --n-size:    14px;
+  --n-weight:  500;
+  --n-gap:     5px;
+  --n-minh:    24px;
+  --n-ease:    0.2s ease;
+  --n-shadow:  0 8px 28px rgba(0,0,0,0.11);
+  --n-radius:  6px;
+  --n-mob-w:   min(320px, 88vw);
+}
+
+/* ---- 1 & 2. Shared base for nav buttons and nav links ---- */
+.main-menu .nav-toggle,
+.main-menu .nav-link {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--n-font);
+  font-size: var(--n-size);
+  font-weight: var(--n-weight);
+  color: var(--n-text);
+  text-decoration: none;
+  padding-block: 7px;
+  padding-inline: 0;
+  min-height: var(--n-minh);
+  line-height: 1.4;
+  white-space: nowrap;
+  position: relative;
+  transition: color var(--n-ease);
+}
+
+/* Button-specific UA resets (not needed on .nav-link <a>) */
+.main-menu .nav-toggle {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  outline: none;
+  margin: 0;
+  cursor: pointer;
+  gap: var(--n-gap);
+}
+
+/* ---- 3. Top-level <li>: flex row so toggle and nav-link sit on one baseline ---- */
+.main-menu nav > ul > li {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* ---- 4. Hover/active color — shared ---- */
+.main-menu ul li:hover > .nav-toggle,
+.main-menu ul li:hover > .nav-link,
+.main-menu .nav-toggle[aria-expanded="true"] {
+  color: var(--n-brand);
+}
+
+/* ---- 5. Animated underline indicator ---- */
+.main-menu .nav-toggle::after,
+.main-menu .nav-link::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  inset-inline-start: 0;
+  width: 0;
+  height: 2px;
+  background: var(--n-brand);
+  border-radius: 1px;
+  transition: width var(--n-ease);
+}
+.main-menu ul li:hover > .nav-toggle::after,
+.main-menu ul li:hover > .nav-link::after,
+.main-menu .nav-toggle[aria-expanded="true"]::after {
+  width: 100%;
+}
+
+/* ---- 6. Chevron rotation ---- */
+.nav-chevron {
+  display: inline-block;
+  flex-shrink: 0;
+  transition: transform var(--n-ease);
+}
+.nav-toggle[aria-expanded="true"] .nav-chevron {
+  transform: rotate(180deg);
+}
+
+/* ---- 7. Smooth submenu reveal: opacity + translateY ---- */
+.main-menu .drop-menu,
+.main-menu .mega-menu-area {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+  transition:
+    opacity var(--n-ease),
+    transform var(--n-ease),
+    visibility 0s linear 0.2s;
+  box-shadow: var(--n-shadow);
+  border-radius: 0 0 var(--n-radius) var(--n-radius);
+  border-top: 3px solid var(--n-brand);
+}
+.main-menu .nav-toggle[aria-expanded="true"] + .drop-menu,
+.main-menu .nav-toggle[aria-expanded="true"] + .mega-menu-area,
+.main-menu li:hover > .drop-menu,
+.main-menu li:hover > .mega-menu-area {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  top: 100%;
+  transition:
+    opacity var(--n-ease),
+    transform var(--n-ease),
+    visibility 0s linear 0s;
+}
+
+/* ---- 8. Focus-visible rings — unified (WCAG 2.4.7 / 2.4.13, ≥3:1 contrast) ---- */
+.main-menu .nav-toggle:focus-visible,
+.main-menu .nav-link:focus-visible,
+.main-menu nav ul li > a:focus-visible,
+.main-menu .drop-menu a:focus-visible,
+.main-menu .mega-menu-area a:focus-visible {
+  outline: 2px solid var(--n-deep);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ---- 9. Min touch-target sizes (WCAG 2.5.8) ---- */
+.main-menu .drop-menu li a,
+.main-menu .mega-menu-area .single-mega-item li a {
+  min-height: var(--n-minh);
+}
+
+/* ---- 10. Contact-bar SVG alignment ---- */
+.call-to-action nav ul li a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.call-to-action nav ul li a svg { flex-shrink: 0; }
+
+/* ---- 11. Active-page indicator (aria-current) ---- */
+.main-menu a[aria-current="page"] {
+  color: var(--n-brand);
+  font-weight: 700;
+}
+
+/* ========================================================================
+   MOBILE NAV — 2026 off-canvas drawer (WCAG 2.2 AA)
+   ======================================================================== */
+
+/* Suppress old mobile system (safety net for un-propagated pages) */
+.mobile-menu-area           { display: none !important; }
+.mean-bar, .meanmenu-reveal { display: none !important; }
+
+/* ---- Hamburger button ---- */
+.mobile-menu-btn {
+  display: none; /* shown via breakpoint below */
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  padding: 8px;
+  cursor: pointer;
+  color: var(--n-text);
+  min-height: 44px;
+  min-width: 44px;
+  line-height: 1;
+  transition: color var(--n-ease);
+}
+.mobile-menu-btn:hover { color: var(--n-brand); }
+.mobile-menu-btn:focus-visible {
+  outline: 2px solid var(--n-deep);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Hamburger lines — animated X */
+.hb-line {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+.mobile-menu-btn[aria-expanded="true"] .hb-top { transform: translateY(8px)  rotate(45deg); }
+.mobile-menu-btn[aria-expanded="true"] .hb-mid { opacity: 0; transform: scaleX(0); }
+.mobile-menu-btn[aria-expanded="true"] .hb-bot { transform: translateY(-8px) rotate(-45deg); }
+
+/* ---- Backdrop overlay ---- */
+.mobile-nav-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.48);
+  z-index: 9996;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0s linear 0.3s;
+}
+.mobile-nav-overlay.is-open {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.3s ease, visibility 0s linear 0s;
+}
+
+/* ---- Off-canvas drawer ---- */
+.mobile-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--n-mob-w);
+  height: 100vh;
+  height: 100dvh;
+  background: #fff;
+  z-index: 9997;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  overflow: hidden;
+  box-shadow: 4px 0 32px rgba(0,0,0,0.16);
+}
+.mobile-nav.is-open { transform: translateX(0); }
+
+/* Drawer header */
+.mobile-nav__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e5e7eb;
+  flex-shrink: 0;
+}
+.mobile-nav__logo { height: 34px; width: auto; }
+
+/* Close button */
+.mobile-nav__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 8px;
+  cursor: pointer;
+  color: #666;
+  border-radius: 4px;
+  min-height: 44px;
+  min-width: 44px;
+  transition: color var(--n-ease);
+}
+.mobile-nav__close:hover { color: var(--n-brand); }
+.mobile-nav__close:focus-visible {
+  outline: 2px solid var(--n-deep);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Scrollable body */
+.mobile-nav__body {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Nav list */
+.mobile-nav__list,
+.mobile-nav__list li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.mobile-nav__list { padding-bottom: 8px; }
+.mobile-nav__item { border-bottom: 1px solid #f0f0f0; }
+
+/* ---- Shared base: top-level plain link (News) + accordion toggle ---- */
+.mobile-nav__link,
+.mobile-nav__toggle {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 14px 20px;
+  font-family: var(--n-font);
+  font-size: 15px;
+  font-weight: 600;
+  color: #333;
+  text-decoration: none;
+  min-height: 48px;
+  transition: color var(--n-ease), background-color var(--n-ease);
+}
+.mobile-nav__link:hover,
+.mobile-nav__toggle:hover { color: var(--n-brand); background-color: #f5f9ff; }
+.mobile-nav__link:focus-visible,
+.mobile-nav__toggle:focus-visible {
+  outline: 2px solid var(--n-deep);
+  outline-offset: -2px;
+  border-radius: 2px;
+}
+
+/* Accordion toggle extras */
+.mobile-nav__toggle {
+  justify-content: space-between;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: start;
+}
+.mobile-nav__toggle[aria-expanded="true"] {
+  color: var(--n-brand);
+  background-color: #f0f5fc;
+}
+
+/* Accordion chevron */
+.mobile-nav__chevron {
+  flex-shrink: 0;
+  color: #aaa;
+  transition: transform 0.25s ease;
+}
+.mobile-nav__toggle[aria-expanded="true"] .mobile-nav__chevron {
+  transform: rotate(180deg);
+  color: var(--n-brand);
+}
+
+/* Accordion submenu — max-height collapse pattern */
+.mobile-nav__sub {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+  background: #f8f9fb;
+}
+.mobile-nav__sub li { list-style: none; margin: 0; padding: 0; }
+.mobile-nav__toggle[aria-expanded="true"] + .mobile-nav__sub {
+  max-height: 1400px; /* generous ceiling for Sciences (22 items) */
+}
+
+/* Section headings inside Sciences accordion */
+.mobile-nav__sub-heading {
+  display: block;
+  padding: 10px 20px 4px;
+  font-family: var(--n-font);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--n-brand);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: #eef3fb;
+  margin-top: 2px;
+}
+
+/* Submenu links */
+.mobile-nav__sub-link {
+  display: flex;
+  align-items: center;
+  padding: 10px 20px 10px 28px;
+  font-family: var(--n-font);
+  font-size: 13px;
+  font-weight: 500;
+  color: #555;
+  text-decoration: none;
+  min-height: 44px;
+  transition: color var(--n-ease), background-color var(--n-ease);
+}
+.mobile-nav__sub-link:hover { color: var(--n-brand); background-color: #eef3fb; }
+.mobile-nav__sub-link:focus-visible {
+  outline: 2px solid var(--n-deep);
+  outline-offset: -2px;
+  border-radius: 2px;
+}
+
+/* Donate strip at drawer bottom */
+.mobile-nav__donate {
+  padding: 16px 20px;
+  border-top: 2px solid #e5e7eb;
+  flex-shrink: 0;
+  background: #fff;
+}
+.mobile-nav__donate a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--n-brand);
+  color: #fff;
+  font-family: var(--n-font);
+  font-size: 14px;
+  font-weight: 700;
+  padding: 12px 24px;
+  border-radius: 4px;
+  text-decoration: none;
+  min-height: 44px;
+  letter-spacing: 0.02em;
+  transition: background-color var(--n-ease);
+}
+.mobile-nav__donate a:hover { background: #0d5fa0; }
+.mobile-nav__donate a:focus-visible {
+  outline: 2px solid var(--n-deep);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+/* Body scroll-lock class (toggled by JS) */
+body.nav-scroll-locked { overflow: hidden; }
+
+/* ---- Responsive breakpoints ---- */
+@media (max-width: 991px) {
+  .mobile-menu-btn               { display: flex !important; }
+  .main-menu-area .main-menu     { display: none !important; }
+  .main-menu-area .donate-button { display: none !important; }
+  /* Logo col: full-width flex row with hamburger on the right */
+  .main-menu-area .col-sm-3 {
+    flex: 0 0 100% !important;
+    max-width: 100% !important;
+    display: flex !important;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  /* 9-col nav wrapper is empty on mobile — hide it */
+  .main-menu-area .col-sm-9 { display: none !important; }
+}
+@media (min-width: 992px) {
+  .mobile-menu-btn    { display: none !important; }
+  .mobile-nav-overlay { display: none !important; }
+  .mobile-nav         { display: none !important; }
+}
+
+/* ---- Consolidated prefers-reduced-motion block ---- */
+@media (prefers-reduced-motion: reduce) {
+  .main-menu .drop-menu,
+  .main-menu .mega-menu-area,
+  .nav-chevron,
+  .main-menu .nav-toggle::after,
+  .main-menu .nav-link::after,
+  .hb-line,
+  .mobile-nav-overlay,
+  .mobile-nav,
+  .mobile-nav__chevron,
+  .mobile-nav__sub {
+    transition: none !important;
+  }
+}

--- a/fellowship/index.html
+++ b/fellowship/index.html
@@ -74,8 +74,12 @@
         </script>
 
         <link rel="stylesheet" href="../master.css">
-        <script src="../js/vendor/modernizr-2.8.3.min.js"></script>
-        <style>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../css/nav-2026.css">
+        <script defer src="../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+<style>
             /* ---- Page-local overrides for the Consortium Fellowship page ---- */
             .cf-hero-cta {
                 display: inline-block;
@@ -393,37 +397,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../index.html">
-                                        <img src="../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../index.html">
+								<img src="../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../mission.html">Mission</a></li>
+                                                    <li><a href="../community/about-us/">About Us</a></li>
+                                                    <li><a href="../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../research/funding/">Funding</a></li>
+                                                    <li><a href="../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../sciences/agriculture/">Agriculture</a></li>
@@ -460,132 +505,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li class="cf-nav-active"><a href="/fellowship/">Fellowship</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../community/about-us/">About Us</a></li>
-                                                    <li><a href="/fellowship/">INSTAR Fellowship</a></li>
-                                                    <li><a href="../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../community/contact/">Contact</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
+                                                    <li><a href="../community/fellowship/">Fellowship</a></li>
+                                                    <li><a href="../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../community/careers/">Careers</a></li>
+                                                    <li><a href="../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="../community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../sciences/geology/">Geology</a></li>
-                                                <li><a href="../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../sciences/economics/">Economics</a></li>
-                                                <li><a href="../sciences/law/">Law</a></li>
-                                                <li><a href="../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../sciences/biology/">Biology</a></li>
-                                                <li><a href="../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../sciences/physics/">Physics</a></li>
-                                                <li><a href="../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../research/innovation/">Innovation</a></li>
-                                                <li><a href="../research/our-process/">Our Process</a></li>
-                                                <li><a href="../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../research/facilities/">Facilities</a></li>
-                                                <li><a href="../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="/fellowship/">Fellowship</a>
-                                            <ul>
-                                                <li><a href="../community/about-us/">About Us</a></li>
-                                                <li><a href="/fellowship/">INSTAR Fellowship</a></li>
-                                                <li><a href="../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../community/contact/">Contact</a></li>
-                                                <li><a href="../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
 

--- a/index.html
+++ b/index.html
@@ -1,11 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if IE 10 ]>    <html lang="en" class="ie10">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -19,9 +12,8 @@
 
         <!-- Favicon
 		============================================ -->
-		<link rel="apple-touch-icon" sizes="180x180" href="img/logo/fav/apple-touch-icon.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="img/logo/fav/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="img/logo/fav/favicon-16x16.png">
+		<link rel="icon" href="img/logo/instar.svg" type="image/svg+xml">
+        <link rel="icon" href="img/logo/fav/favicon.ico" sizes="any">
         <link rel="manifest" href="img/logo/fav/site.webmanifest">
 
         <!-- Open Graph
@@ -92,15 +84,15 @@
         ============================================ -->
         <link rel="stylesheet" href="master.css">
 
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
 
     </head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
-        <!--[if lt IE 8]>
-            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-        <![endif]-->
-
 		<!-- Start main area -->
         <div class="main-area">
         	<!-- Start header -->
@@ -113,38 +105,79 @@
 	                            <div class="top-social"></div>
 	                        </div>
 	                        <div class="col-sm-7 col-md-6">
-	                            <div class="call-to-action">
-	                                <nav>
-	                                	<ul>
-		                                	<li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-		                                	<li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-		                                	<li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-		                                	</li>
+	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+		                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+		                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+		                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
 		                                </ul>
-	                                </nav>
-	                            </div>
+                                </nav>
+                            </div>
+                            <!-- NAV-2026-TOPBAR:END -->
 	                        </div>
         				</div>
         			</div>
         		</div>
         		<!-- End header top -->
-        		<!-- Start main menu area -->
-        		<div class="main-menu-area" id="sticker">
-        			<div class="container">
-        				<div class="row">
-        					<div class="col-sm-3 col-12">
-        						<div class="logo ptb-32">
-        							<a href="index.html">
-        								<img src="img/logo/instar.svg" alt="INSTAR Lab">
-        							</a>
-        						</div>
-        					</div>
-        					<div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="sciences/agriculture/">Agriculture</a></li>
@@ -181,132 +214,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="technology/data-science/">Data Science</a></li>
                                                     <li><a href="technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="research/innovation/">Innovation</a></li>
-                                                    <li><a href="research/our-process/">Our Process</a></li>
-                                                    <li><a href="research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="research/facilities/">Facilities</a></li>
-                                                    <li><a href="research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="community/contact/">Contact</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="community/contact/">Donate</a>
-        						</div>
-        					</div>
-        				</div>
-        			</div>
-        		</div>
-        		<!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
         	</header>
         	<!-- End header -->
             <main id="main-content">
@@ -425,7 +507,6 @@
         				<div class="col-sm-12">
         					<div class="section-title text-center">
         						<h2>RESEARCH <span>PROGRAMS</span></h2>
-        						<img src="img/title-bottom.png" alt="">
         						<p>Applied R&amp;D at the frontier of scientific discovery</p>
         					</div>
         				</div>
@@ -553,7 +634,6 @@
                         <div class="col-sm-12">
                             <div class="section-title text-center">
                                 <h2>OUR <span>RESEARCH</span></h2>
-                                <img src="img/title-bottom.png" alt="">
                                 <p>An independent 501(c)(3) research institute advancing science across AI, health, energy, quantum, HPC, space, and the broad sciences. <br>Explore our research areas and technical capabilities below.</p>
                             </div>
                         </div>
@@ -743,7 +823,6 @@
                         <div class="col-sm-12">
                             <div class="section-title text-center">
                                 <h2>OUR <span>LEADERSHIP</span></h2>
-                                <img src="img/title-bottom.png" alt="">
                                 <p>INSTAR Lab is led by experienced scientists, engineers, and researchers whose work spans applied AI, physics, and technology transfer. Our leadership team brings decades of production research, federal R&amp;D, and scientific governance to every program we run.</p>
                             </div>
                         </div>
@@ -816,7 +895,6 @@
                         <div class="col-sm-12">
                             <div class="people-asy-title text-center">
                                 <h2>WHAT PEOPLE SAYS</h2>
-                                <img src="img/title-bottom.png" alt="">
                             </div>
                             <div class="people-say-slide">
                                 <!-- Start single people -->
@@ -869,7 +947,6 @@
                         <div class="col-sm-12">
                             <div class="section-title text-center">
                                 <h2>LATEST FROM <span>LABS</span></h2>
-                                <img src="img/title-bottom.png" alt="">
                                 <p>Technical briefs, STTR highlights, and research updates from INSTAR Lab <br>and the INSTAR Consortium — published as work matures.</p>
                             </div>
                         </div>
@@ -947,7 +1024,6 @@
                         <div class="col-sm-12">
                             <div class="section-title text-center">
                                 <h2>OUR <span>PARTNERS</span></h2>
-                                <img src="img/title-bottom.png" alt="">
                             </div>
                         </div>
                         <!-- End section title -->

--- a/js/nav-2026.js
+++ b/js/nav-2026.js
@@ -1,0 +1,169 @@
+/**
+ * nav-2026.js — INSTAR Lab 2026 Navigation
+ * W3C APG Disclosure Navigation + WCAG 2.2 AA off-canvas mobile drawer.
+ * No jQuery. Loaded with defer — runs after DOM parse.
+ */
+(function () {
+  'use strict';
+
+  function init() {
+
+    /* ============================================================
+       DESKTOP — W3C APG Disclosure Navigation
+       ============================================================ */
+    var nav = document.querySelector('.main-menu nav');
+    if (!nav) return;
+
+    var toggles = Array.from(nav.querySelectorAll('.nav-toggle'));
+
+    function getSubmenu(t) {
+      return document.getElementById(t.getAttribute('aria-controls'));
+    }
+    function closeAll() {
+      toggles.forEach(function (t) { t.setAttribute('aria-expanded', 'false'); });
+    }
+    function openToggle(t) {
+      toggles.forEach(function (s) { if (s !== t) s.setAttribute('aria-expanded', 'false'); });
+      t.setAttribute('aria-expanded', 'true');
+    }
+
+    /* Click */
+    toggles.forEach(function (t) {
+      t.addEventListener('click', function (e) {
+        e.stopPropagation();
+        var open = t.getAttribute('aria-expanded') === 'true';
+        closeAll();
+        if (!open) openToggle(t);
+      });
+    });
+
+    /* ArrowDown: move focus into first submenu link */
+    toggles.forEach(function (t) {
+      t.addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          var sub = getSubmenu(t);
+          if (sub) { openToggle(t); var a = sub.querySelector('a'); if (a) a.focus(); }
+        }
+      });
+    });
+
+    /* Focusout: close when focus leaves nav (WCAG 1.4.13) */
+    nav.addEventListener('focusout', function (e) {
+      if (!e.relatedTarget || !nav.contains(e.relatedTarget)) {
+        setTimeout(closeAll, 0);
+      }
+    });
+
+    /* Outside click */
+    document.addEventListener('click', function (e) {
+      if (!nav.contains(e.target)) closeAll();
+    });
+
+    /* Hover: progressive enhancement with 200 ms grace period */
+    var timers = new Map();
+    toggles.forEach(function (t) {
+      var li  = t.closest('li');
+      var sub = getSubmenu(t);
+      if (!li) return;
+      function cancel()   { clearTimeout(timers.get(t)); }
+      /* Use closeAll so any future close-path logic (e.g. focus management)
+         stays in one place rather than being duplicated here. */
+      function schedule() { timers.set(t, setTimeout(closeAll, 200)); }
+      li.addEventListener('mouseenter', function () { cancel(); openToggle(t); });
+      li.addEventListener('mouseleave', schedule);
+      if (sub) { sub.addEventListener('mouseenter', cancel); sub.addEventListener('mouseleave', schedule); }
+    });
+
+    /* ============================================================
+       MOBILE — off-canvas drawer (vanilla, no jQuery/meanmenu)
+       ============================================================ */
+    var hamburger = document.querySelector('.mobile-menu-btn');
+    var overlay   = document.querySelector('.mobile-nav-overlay');
+    var drawer    = document.getElementById('mobile-nav');
+    var closeBtn  = drawer && drawer.querySelector('.mobile-nav__close');
+
+    if (!hamburger || !overlay || !drawer) return;
+
+    /* Focusable set is cached per open gesture (static drawer DOM). */
+    var cachedFocusables = null;
+    function focusables() {
+      if (!cachedFocusables) {
+        cachedFocusables = Array.from(drawer.querySelectorAll(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        ));
+      }
+      return cachedFocusables;
+    }
+
+    function openDrawer() {
+      cachedFocusables = null; /* reset so Tab sees fresh set on each open */
+      drawer.classList.add('is-open');
+      overlay.classList.add('is-open');
+      document.body.classList.add('nav-scroll-locked');
+      hamburger.setAttribute('aria-expanded', 'true');
+      drawer.removeAttribute('aria-hidden');
+      if (closeBtn) closeBtn.focus();
+    }
+
+    function closeDrawer() {
+      cachedFocusables = null;
+      drawer.classList.remove('is-open');
+      overlay.classList.remove('is-open');
+      document.body.classList.remove('nav-scroll-locked');
+      hamburger.setAttribute('aria-expanded', 'false');
+      drawer.setAttribute('aria-hidden', 'true');
+      hamburger.focus();
+    }
+
+    hamburger.addEventListener('click', function () {
+      drawer.classList.contains('is-open') ? closeDrawer() : openDrawer();
+    });
+    overlay.addEventListener('click', closeDrawer);
+    if (closeBtn) closeBtn.addEventListener('click', closeDrawer);
+
+    /* Unified Esc handler — covers both desktop submenus and mobile drawer.
+       Check mobile first; desktop guard inlines getOpen() at its single call site. */
+    document.addEventListener('keydown', function (e) {
+      if (e.key !== 'Escape') return;
+      if (drawer.classList.contains('is-open')) { closeDrawer(); return; }
+      var o = nav.querySelector('.nav-toggle[aria-expanded="true"]');
+      if (o) { closeAll(); o.focus(); }
+    });
+
+    /* Focus trap: Tab/Shift+Tab cycles within drawer */
+    drawer.addEventListener('keydown', function (e) {
+      if (e.key !== 'Tab') return;
+      var f = focusables();
+      if (!f.length) return;
+      if (e.shiftKey) {
+        if (document.activeElement === f[0]) { e.preventDefault(); f[f.length - 1].focus(); }
+      } else {
+        if (document.activeElement === f[f.length - 1]) { e.preventDefault(); f[0].focus(); }
+      }
+    });
+
+    /* Close on leaf-link click (navigation complete) */
+    drawer.querySelectorAll('.mobile-nav__sub-link, .mobile-nav__link').forEach(function (a) {
+      a.addEventListener('click', closeDrawer);
+    });
+
+    /* Accordion: one section open at a time — toggle set cached once */
+    var mobileToggles = Array.from(drawer.querySelectorAll('.mobile-nav__toggle'));
+    mobileToggles.forEach(function (t) {
+      t.addEventListener('click', function () {
+        var expanded = t.getAttribute('aria-expanded') === 'true';
+        mobileToggles.forEach(function (s) {
+          if (s !== t) s.setAttribute('aria-expanded', 'false');
+        });
+        t.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+}());

--- a/labs/biometric-security/index.html
+++ b/labs/biometric-security/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -80,38 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-    						<div class="main-menu">
-    							<nav>
-    								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -148,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-    								</ul>
-    							</nav>
-    						</div>
-    						<div class="donate-button ptb-32">
-    							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-    						</div>
-    					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/labs/cognitive-ai/index.html
+++ b/labs/cognitive-ai/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -80,38 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-    						<div class="main-menu">
-    							<nav>
-    								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -148,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-    								</ul>
-    							</nav>
-    						</div>
-    						<div class="donate-button ptb-32">
-    							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-    						</div>
-    					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/labs/sovereign-ai/index.html
+++ b/labs/sovereign-ai/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -80,38 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-    						<div class="main-menu">
-    							<nav>
-    								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -148,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-    								</ul>
-    							</nav>
-    						</div>
-    						<div class="donate-button ptb-32">
-    							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-    						</div>
-    					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/mission.html
+++ b/mission.html
@@ -1,10 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -93,10 +87,12 @@
         <!-- master CSS
         ============================================ -->
         <link rel="stylesheet" href="master.css">
-
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!--[if lt IE 8]>
@@ -115,200 +111,289 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-	                                        </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="index.html">
-                                        <img src="img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-    						<div class="main-menu">
-    							<nav>
-    								<ul>
-                                        <li  class="mega-menu"><a href="#">Sciences</a>
-                                            <div class="mega-menu-area">
-                                                <ul class="single-mega-item">
-                                                    <li class="shortcode-title">Earth &amp; Space</li>
-                                                    <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                    <li><a href="sciences/geology/">Geology</a></li>
-                                                    <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                    <li><a href="sciences/outer-space/">Outer Space</a></li>
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html" aria-current="page">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
                                                 </ul>
-                                                <ul class="single-mega-item">
-                                                    <li class="shortcode-title">Social Sciences</li>
-                                                    <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                    <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                    <li><a href="sciences/economics/">Economics</a></li>
-                                                    <li><a href="sciences/law/">Law</a></li>
-                                                    <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                    <li><a href="sciences/psychology/">Psychology</a></li>
-                                                    <li><a href="sciences/sociology/">Sociology</a></li>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
                                                 </ul>
-                                                <ul class="single-mega-item">
-                                                    <li class="shortcode-title">Life Sciences</li>
-                                                    <li><a href="sciences/biology/">Biology</a></li>
-                                                    <li><a href="sciences/genetics/">Genetics</a></li>
-                                                    <li><a href="sciences/medicine/">Medicine</a></li>
-                                                    <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                    <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                    <li><a href="sciences/physiology/">Physiology</a></li>
-                                                    <li><a href="sciences/kinesiology/">Kinesiology</a></li>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Earth &amp; Space</li>
+                                                        <li><a href="sciences/agriculture/">Agriculture</a></li>
+                                                        <li><a href="sciences/geology/">Geology</a></li>
+                                                        <li><a href="sciences/ocean-science/">Ocean Science</a></li>
+                                                        <li><a href="sciences/outer-space/">Outer Space</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Social Sciences</li>
+                                                        <li><a href="sciences/anthropology/">Anthropology</a></li>
+                                                        <li><a href="sciences/archaeology/">Archaeology</a></li>
+                                                        <li><a href="sciences/economics/">Economics</a></li>
+                                                        <li><a href="sciences/law/">Law</a></li>
+                                                        <li><a href="sciences/linguistics/">Linguistics</a></li>
+                                                        <li><a href="sciences/psychology/">Psychology</a></li>
+                                                        <li><a href="sciences/sociology/">Sociology</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Life Sciences</li>
+                                                        <li><a href="sciences/biology/">Biology</a></li>
+                                                        <li><a href="sciences/genetics/">Genetics</a></li>
+                                                        <li><a href="sciences/medicine/">Medicine</a></li>
+                                                        <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                                                        <li><a href="sciences/neuroscience/">Neuroscience</a></li>
+                                                        <li><a href="sciences/physiology/">Physiology</a></li>
+                                                        <li><a href="sciences/kinesiology/">Kinesiology</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Physical Sciences</li>
+                                                        <li><a href="sciences/chemistry/">Chemistry</a></li>
+                                                        <li><a href="sciences/physics/">Physics</a></li>
+                                                        <li><a href="sciences/materials-science/">Materials Science</a></li>
+                                                        <li><a href="sciences/energy/">Energy</a></li>
+                                                    </ul>
+                                                </div>
+                                            </li>
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
+                                                    <li><a href="technology/formal-methods/">Formal Methods</a></li>
+                                                    <li><a href="technology/data-science/">Data Science</a></li>
+                                                    <li><a href="technology/computer-science/">Computer Science</a></li>
+                                                    <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                                                    <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
+                                                    <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
-                                                <ul class="single-mega-item">
-                                                    <li class="shortcode-title">Physical Sciences</li>
-                                                    <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                    <li><a href="sciences/physics/">Physics</a></li>
-                                                    <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                    <li><a href="sciences/energy/">Energy</a></li>
+                                            </li>
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
+                                                    <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                                                    <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                                                    <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
+                                                    <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
-                                            </div>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul class="drop-menu">
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-    								<li><a href="#">Tech Transfer</a>
-                                            <ul class="drop-menu">
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-    								<li><a href="#">Research</a>
-                                            <ul class="drop-menu">
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul class="drop-menu">
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-    							</ul>
-    						</nav>
-    					</div>
-    					<div class="donate-button ptb-32">
-    						<a class="waves-effect waves-light" href="community/contact/">Donate</a>
-    					</div>
-    				</div>
-                    </div>
-                </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            </li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
+                                                    <li><a href="community/fellowship/">Fellowship</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
+                                                    <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html" aria-current="page">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/news/clinical-ai-safety/index.html
+++ b/news/clinical-ai-safety/index.html
@@ -57,8 +57,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!-- Start main area -->
@@ -73,37 +77,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -140,132 +185,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/news/hpc-infrastructure-for-ai/index.html
+++ b/news/hpc-infrastructure-for-ai/index.html
@@ -57,8 +57,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!-- Start main area -->
@@ -73,37 +77,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -140,132 +185,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/news/index.html
+++ b/news/index.html
@@ -1,0 +1,620 @@
+<!doctype html>
+<html class="no-js" lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>News — INSTAR Lab</title>
+        <meta name="description" content="Updates, announcements, and research highlights from INSTAR Lab — an independent 501(c)(3) nonprofit research institute.">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="canonical" href="https://instarlab.org/news/">
+        <meta name="robots" content="index, follow">
+        <meta name="theme-color" content="#1072ba">
+
+        <!-- Favicon
+        ============================================ -->
+        <link rel="apple-touch-icon" sizes="180x180" href="../img/logo/fav/apple-touch-icon.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="../img/logo/fav/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="../img/logo/fav/favicon-16x16.png">
+        <link rel="manifest" href="../img/logo/fav/site.webmanifest">
+
+        <!-- Open Graph
+        ============================================ -->
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="https://instarlab.org/news/">
+        <meta property="og:title" content="News — INSTAR Lab">
+        <meta property="og:description" content="Updates, announcements, and research highlights from INSTAR Lab — an independent 501(c)(3) nonprofit research institute.">
+        <meta property="og:image" content="https://instarlab.org/img/og/default.jpg">
+        <meta property="og:image:alt" content="News and research updates from INSTAR Lab">
+        <meta property="og:site_name" content="INSTAR Lab">
+
+        <!-- Twitter Card
+        ============================================ -->
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:site" content="@INSTARLab">
+        <meta name="twitter:title" content="News — INSTAR Lab">
+        <meta name="twitter:description" content="Updates, announcements, and research highlights from INSTAR Lab — an independent 501(c)(3) nonprofit research institute.">
+        <meta name="twitter:image" content="https://instarlab.org/img/og/default.jpg">
+
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "CollectionPage",
+          "name": "News — INSTAR Lab",
+          "description": "Updates, announcements, and research highlights from INSTAR Lab.",
+          "url": "https://instarlab.org/news/",
+          "inLanguage": "en-US",
+          "isPartOf": {
+            "@type": "WebSite",
+            "name": "INSTAR Lab",
+            "url": "https://instarlab.org/"
+          },
+          "breadcrumb": {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://instarlab.org/" },
+              { "@type": "ListItem", "position": 2, "name": "News", "item": "https://instarlab.org/news/" }
+            ]
+          }
+        }
+        </script>
+
+        <!-- master CSS
+        ============================================ -->
+        <link rel="stylesheet" href="../master.css">
+
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../css/nav-2026.css">
+        <script defer src="../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+    </head>
+    <body>
+        <a class="skip-to-content" href="#main-content">Skip to main content</a>
+        <!-- Start main area -->
+        <div class="main-area">
+            <!-- Start header -->
+            <header>
+                <!-- Start header top -->
+                <div class="header-top">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-5 col-md-6">
+                                <div class="top-social"></div>
+                            </div>
+                            <div class="col-sm-7 col-md-6">
+                                <!-- NAV-2026-TOPBAR:START -->
+                                <div class="call-to-action">
+                                    <nav aria-label="Contact">
+                                        <ul>
+                                            <li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+                                            <li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+                                            <li><a href="../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+                                        </ul>
+                                    </nav>
+                                </div>
+                                <!-- NAV-2026-TOPBAR:END -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- End header top -->
+                <!-- NAV-2026:START -->
+                <!-- Start main menu area -->
+                <div class="main-menu-area" id="sticker">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-3 col-12">
+                                <div class="logo ptb-32">
+                                    <a href="../index.html">
+                                        <img src="../img/logo/instar.svg" alt="INSTAR Lab">
+                                    </a>
+                                </div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+                            </div>
+                            <div class="col-sm-9 col-12">
+                                <div class="donate-button ptb-32">
+                                    <a class="waves-effect waves-light" href="../community/support/">Donate</a>
+                                </div>
+                                <div class="main-menu">
+                                    <nav aria-label="Main">
+                                        <ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../mission.html">Mission</a></li>
+                                                    <li><a href="../community/about-us/">About Us</a></li>
+                                                    <li><a href="../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../research/funding/">Funding</a></li>
+                                                    <li><a href="../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Earth &amp; Space</li>
+                                                        <li><a href="../sciences/agriculture/">Agriculture</a></li>
+                                                        <li><a href="../sciences/geology/">Geology</a></li>
+                                                        <li><a href="../sciences/ocean-science/">Ocean Science</a></li>
+                                                        <li><a href="../sciences/outer-space/">Outer Space</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Social Sciences</li>
+                                                        <li><a href="../sciences/anthropology/">Anthropology</a></li>
+                                                        <li><a href="../sciences/archaeology/">Archaeology</a></li>
+                                                        <li><a href="../sciences/economics/">Economics</a></li>
+                                                        <li><a href="../sciences/law/">Law</a></li>
+                                                        <li><a href="../sciences/linguistics/">Linguistics</a></li>
+                                                        <li><a href="../sciences/psychology/">Psychology</a></li>
+                                                        <li><a href="../sciences/sociology/">Sociology</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Life Sciences</li>
+                                                        <li><a href="../sciences/biology/">Biology</a></li>
+                                                        <li><a href="../sciences/genetics/">Genetics</a></li>
+                                                        <li><a href="../sciences/medicine/">Medicine</a></li>
+                                                        <li><a href="../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                                                        <li><a href="../sciences/neuroscience/">Neuroscience</a></li>
+                                                        <li><a href="../sciences/physiology/">Physiology</a></li>
+                                                        <li><a href="../sciences/kinesiology/">Kinesiology</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Physical Sciences</li>
+                                                        <li><a href="../sciences/chemistry/">Chemistry</a></li>
+                                                        <li><a href="../sciences/physics/">Physics</a></li>
+                                                        <li><a href="../sciences/materials-science/">Materials Science</a></li>
+                                                        <li><a href="../sciences/energy/">Energy</a></li>
+                                                    </ul>
+                                                </div>
+                                            </li>
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
+                                                    <li><a href="../technology/formal-methods/">Formal Methods</a></li>
+                                                    <li><a href="../technology/data-science/">Data Science</a></li>
+                                                    <li><a href="../technology/computer-science/">Computer Science</a></li>
+                                                    <li><a href="../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../technology/natural-language-processing/">Natural Language Processing</a></li>
+                                                    <li><a href="../technology/augmented-reality/">Augmented Reality</a></li>
+                                                    <li><a href="../technology/quantum-computing/">Quantum Computing</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 5. Tech Transfer -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
+                                                    <li><a href="../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                                                    <li><a href="../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                                                    <li><a href="../tech-transfer/portfolio/">Portfolio</a></li>
+                                                    <li><a href="../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
+                                                    <li><a href="../community/fellowship/">Fellowship</a></li>
+                                                    <li><a href="../community/work-with-us/">Collaborate</a></li>
+                                                    <li><a href="../community/careers/">Careers</a></li>
+                                                    <li><a href="../community/contact/">Contact</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 7. News (direct link, current page) -->
+                                            <li><a class="nav-link" href="../news/" aria-current="page">News</a></li>
+                                        </ul>
+                                    </nav>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- End main menu area -->
+                <!-- Mobile nav backdrop -->
+                <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+                <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+                <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+                    <div class="mobile-nav__header">
+                        <img src="../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                        <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                            <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                                <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                                <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="mobile-nav__body">
+                        <ul class="mobile-nav__list">
+                            <!-- 1. About -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                                    About
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-about">
+                                    <li><a class="mobile-nav__sub-link" href="../mission.html">Mission</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../community/about-us/">About Us</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../community/leadership/">Leadership</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../research/consortium/">INSTAR Consortium</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../research/facilities/">Facilities</a></li>
+                                </ul>
+                            </li>
+                            <!-- 2. Research -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                                    Research
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-research">
+                                    <li><a class="mobile-nav__sub-link" href="../research/innovation/">Innovation</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../research/our-process/">Our Process</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../research/current-programs/">Current Programs</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../research/funding/">Funding</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../research/open-data/">Open Data</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../research/opportunities/">Opportunities</a></li>
+                                </ul>
+                            </li>
+                            <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                                    Sciences
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                                    <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/agriculture/">Agriculture</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/geology/">Geology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/ocean-science/">Ocean Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/outer-space/">Outer Space</a></li>
+                                    <li class="mobile-nav__sub-heading">Social Sciences</li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/anthropology/">Anthropology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/archaeology/">Archaeology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/economics/">Economics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/law/">Law</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/linguistics/">Linguistics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/psychology/">Psychology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/sociology/">Sociology</a></li>
+                                    <li class="mobile-nav__sub-heading">Life Sciences</li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/biology/">Biology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/genetics/">Genetics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/medicine/">Medicine</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/neuroscience/">Neuroscience</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/physiology/">Physiology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/kinesiology/">Kinesiology</a></li>
+                                    <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/chemistry/">Chemistry</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/physics/">Physics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/materials-science/">Materials Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../sciences/energy/">Energy</a></li>
+                                </ul>
+                            </li>
+                            <!-- 4. Technology -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                                    Technology
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-technology">
+                                    <li><a class="mobile-nav__sub-link" href="../technology/formal-methods/">Formal Methods</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../technology/data-science/">Data Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../technology/computer-science/">Computer Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../technology/natural-language-processing/">Natural Language Processing</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../technology/augmented-reality/">Augmented Reality</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../technology/quantum-computing/">Quantum Computing</a></li>
+                                </ul>
+                            </li>
+                            <!-- 5. Tech Transfer -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                                    Tech Transfer
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                                    <li><a class="mobile-nav__sub-link" href="../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../tech-transfer/portfolio/">Portfolio</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                                </ul>
+                            </li>
+                            <!-- 6. Community -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                                    Community
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-community">
+                                    <li><a class="mobile-nav__sub-link" href="../community/fellowship/">Fellowship</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../community/work-with-us/">Collaborate</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../community/careers/">Careers</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../community/contact/">Contact</a></li>
+                                </ul>
+                            </li>
+                            <!-- 7. News (current page) -->
+                            <li class="mobile-nav__item">
+                                <a class="mobile-nav__link" href="../news/" aria-current="page">News</a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="mobile-nav__donate">
+                        <a href="../community/support/">Donate</a>
+                    </div>
+                </nav>
+                <!-- NAV-2026:END -->
+            </header>
+            <!-- End header -->
+
+            <main id="main-content">
+                <!-- Start page title -->
+                <section class="page-title-area">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-12">
+                                <div class="page-title text-center">
+                                    <h1>NEWS</h1>
+                                </div>
+                                <div class="breadcumb-area text-center">
+                                    <nav aria-label="breadcrumb"><ol class="breadcrumb">
+                                        <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+                                        <li class="breadcrumb-item active" aria-current="page">News</li>
+                                    </ol></nav>
+                                </div>
+                                <div class="back-home">
+                                    <a href="../index.html"><i class="fa fa-arrow-left" aria-hidden="true"></i> BACK TO HOME</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End page title -->
+
+                <!-- Start news intro -->
+                <section class="ip-section">
+                    <div class="container">
+                        <div class="ip-card-grid__intro">
+                            <h2>INSTAR <span>LAB NEWS</span></h2>
+                            <div class="ip-section-title__bar"></div>
+                            <p>Updates, announcements, and research highlights from INSTAR Lab and the INSTAR Consortium — published as work matures.</p>
+                        </div>
+                    </div>
+                </section>
+                <!-- End news intro -->
+
+                <!-- Start news listing -->
+                <section class="blog-area pt-60 pb-90">
+                    <div class="container">
+                        <div class="row">
+                            <div class="blog row">
+                                <!-- Start single blog -->
+                                <div class="col-sm-4">
+                                    <div class="single-blog">
+                                        <div class="blo-image-and-date">
+                                            <img src="../img/blog/blog-one.avif" alt="Quantum sensing research visualization">
+                                        </div>
+                                        <div class="blog-info">
+                                            <div class="admin">
+                                                <a href="quantum-sensing-breakthroughs/"><i class="fa fa-user" aria-hidden="true"></i> By: INSTAR Lab</a>
+                                            </div>
+                                        </div>
+                                        <div class="blog-text">
+                                            <h2><a href="quantum-sensing-breakthroughs/">Quantum sensing breakthroughs</a></h2>
+                                            <p>New approaches to qubit coherence and quantum error correction are enabling practical advances in sensing and computation.</p>
+                                            <a href="quantum-sensing-breakthroughs/">Read More...</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- End single blog -->
+                                <!-- Start single blog -->
+                                <div class="col-sm-4">
+                                    <div class="single-blog">
+                                        <div class="blo-image-and-date">
+                                            <img src="../img/blog/blog-two.avif" alt="HPC compute cluster for AI research">
+                                        </div>
+                                        <div class="blog-info">
+                                            <div class="admin">
+                                                <a href="hpc-infrastructure-for-ai/"><i class="fa fa-user" aria-hidden="true"></i> By: INSTAR Lab</a>
+                                            </div>
+                                        </div>
+                                        <div class="blog-text">
+                                            <h2><a href="hpc-infrastructure-for-ai/">HPC infrastructure for AI</a></h2>
+                                            <p>GPU-accelerated clusters and distributed compute architectures are reshaping how researchers train models and run simulations.</p>
+                                            <a href="hpc-infrastructure-for-ai/">Read More...</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- End single blog -->
+                                <!-- Start single blog -->
+                                <div class="col-sm-4">
+                                    <div class="single-blog">
+                                        <div class="blo-image-and-date">
+                                            <img src="../img/blog/blog-three.avif" alt="Clinical AI safety and healthcare outcomes">
+                                        </div>
+                                        <div class="blog-info">
+                                            <div class="admin">
+                                                <a href="clinical-ai-safety/"><i class="fa fa-user" aria-hidden="true"></i> By: INSTAR Lab</a>
+                                            </div>
+                                        </div>
+                                        <div class="blog-text">
+                                            <h2><a href="clinical-ai-safety/">Clinical AI safety research</a></h2>
+                                            <p>Examining how artificial intelligence can improve patient safety, clinical workflows, and healthcare outcomes at national scale.</p>
+                                            <a href="clinical-ai-safety/">Read More...</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- End single blog -->
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End news listing -->
+
+                <!-- Start newsletter / stay connected -->
+                <section class="countdown-area pt-60 pb-60">
+                    <div class="container">
+                        <div class="row" style="align-items:center;">
+                            <div class="col-sm-5 col-md-4">
+                                <div class="countdown-side-area">
+                                    <div class="countdown-icon">
+                                        <i class="fa fa-envelope-o" aria-hidden="true"></i>
+                                    </div>
+                                    <div class="countdown-text">
+                                        <h3>Stay Connected</h3>
+                                        <p>INSTAR LAB CONSORTIUM</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-7 col-md-8">
+                                <div class="count-down" style="display:flex; align-items:center; height:100%; padding:12px 0;">
+                                    <p style="color:#fff; font-size:16px; line-height:1.7; margin:0;">
+                                        Subscribe to receive INSTAR Lab research highlights and announcements, or <a href="../community/contact/" style="color:#fff; text-decoration:underline; font-weight:600;">contact us</a> to learn how to partner with or support the institute.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End newsletter / stay connected -->
+            </main>
+
+            <!-- Start footer -->
+            <footer>
+                <div class="footer-top pt-50 pb-50">
+                    <div class="container">
+                        <div class="row">
+                            <div class="footer-widget-area row">
+                                <div class="col-sm-4">
+                                    <div class="footer-widget widget-one">
+                                        <div class="footer-widget-title">
+                                            <h3>ABOUT US</h3>
+                                        </div>
+                                        <div class="widget-about-content">
+                                            <p>INSTAR Lab is an independent 501(c)(3) nonprofit research institute advancing science through interdisciplinary collaboration, technological innovation, and partnership.</p>
+                                        </div>
+                                        <div class="widget-contact-content">
+                                            <h3>CONTACT US</h3>
+                                            <a href="tel:+18552214692">Phone: +1 855-221-4692</a>
+                                            <a href="mailto:info@instarlab.org">Email: info@instarlab.org</a>
+                                            <a href="https://maps.google.com/?q=125+Frederick+St+Marietta+OH+45750">Address: 125 Frederick St, Marietta, OH 45750</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2">
+                                    <div class="footer-widget widget-two">
+                                        <div class="footer-widget-title">
+                                            <h3>OUR RESEARCH</h3>
+                                        </div>
+                                        <nav>
+                                            <ul>
+                                                <li><a href="../technology/machine-intelligence/">AI &amp; ML</a></li>
+                                                <li><a href="../technology/quantum-computing/">Quantum Science</a></li>
+                                                <li><a href="../technology/data-science/">Data Analytics</a></li>
+                                                <li><a href="../sciences/medicine/">Health Research</a></li>
+                                                <li><a href="../sciences/energy/">Energy</a></li>
+                                                <li><a href="../technology/computer-science/">HPC Systems</a></li>
+                                            </ul>
+                                        </nav>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2">
+                                    <div class="footer-widget widget-two">
+                                        <div class="footer-widget-title">
+                                            <h3>QUICK LINK</h3>
+                                        </div>
+                                        <nav>
+                                            <ul>
+                                                <li><a href="../community/about-us/">About Us</a></li>
+                                                <li><a href="../community/fellowship/">Fellowship</a></li>
+                                                <li><a href="../community/careers/">Careers</a></li>
+                                                <li><a href="../terms.html">Terms of use</a></li>
+                                                <li><a href="../accessibility.html">Accessibility</a></li>
+                                                <li><a href="../privacy.html">Privacy policy</a></li>
+                                            </ul>
+                                        </nav>
+                                    </div>
+                                </div>
+                                <div class="col-sm-4">
+                                    <div class="footer-widget widget-four">
+                                        <div class="footer-widget-title">
+                                            <h3>NEWSLETTER</h3>
+                                        </div>
+                                        <div class="widget-about-content">
+                                            <p>Select your newsletters, enter your email address, and click "Subscribe"</p>
+                                        </div>
+                                        <div class="newslater">
+                                            <form id="mc-form" class="mc-form form">
+                                                <input id="mc-email" type="email" autocomplete="off" placeholder="Email Address" aria-label="Email address for newsletter">
+                                                <button id="mc-submit" type="submit" aria-label="Subscribe to newsletter"><i class="fa fa-envelope" aria-hidden="true"></i></button>
+                                            </form>
+                                            <div class="mailchimp-alerts text-center">
+                                                <div class="mailchimp-submitting"></div>
+                                                <div class="mailchimp-success"></div>
+                                                <div class="mailchimp-error"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="footer-bottom">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-8">
+                                <div class="copyright">
+                                    <p>INSTAR Lab Inc. is a registered 501(c)(3) nonprofit. Copyright &copy; 2026 INSTAR Lab Inc. All Rights Reserved.</p>
+                                </div>
+                            </div>
+                            <div class="col-sm-4">
+                                <div class="footer-social"></div>
+                            </div>
+                        </div>
+                        <div class="d-none d-sm-block" id="back-top" aria-label="Back to top" role="button" tabindex="0"></div>
+                    </div>
+                </div>
+            </footer>
+            <!-- End footer -->
+        </div>
+        <!-- End main area -->
+
+        <script src="../js/vendor/jquery-1.12.0.min.js"></script>
+        <script src="../js/bootstrap.min.js"></script>
+        <script src="../js/owl.carousel.min.js"></script>
+        <script src="../js/jquery.nivo.slider.pack.js"></script>
+        <script src="../js/jquery.mixitup.min.js"></script>
+        <script src="../js/jquery.magnific-popup.min.js"></script>
+        <script src="../js/jquery.meanmenu.js"></script>
+        <script src="../js/wow.js"></script>
+        <script src="../js/jquery.scrollUp.min.js"></script>
+        <script src="../js/jquery.ajaxchimp.min.js"></script>
+        <script src="../js/plugins.js"></script>
+        <script>new WOW().init();</script>
+        <script src="../js/styleswitch.js"></script>
+        <script src="../js/main.js"></script>
+    </body>
+</html>

--- a/news/quantum-sensing-breakthroughs/index.html
+++ b/news/quantum-sensing-breakthroughs/index.html
@@ -57,8 +57,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!-- Start main area -->
@@ -73,37 +77,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -140,132 +185,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/privacy.html
+++ b/privacy.html
@@ -1,10 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -80,9 +74,12 @@
 
         <!-- master CSS -->
         <link rel="stylesheet" href="master.css">
-
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!--[if lt IE 8]>
@@ -101,37 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="index.html">
-                                        <img src="img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="sciences/agriculture/">Agriculture</a></li>
@@ -168,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="technology/data-science/">Data Science</a></li>
                                                     <li><a href="technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="research/innovation/">Innovation</a></li>
-                                                    <li><a href="research/our-process/">Our Process</a></li>
-                                                    <li><a href="research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="research/facilities/">Facilities</a></li>
-                                                    <li><a href="research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="community/contact/">Contact</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/research/consortium/index.html
+++ b/research/consortium/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/" aria-current="page">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/" aria-current="page">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/research/current-programs/index.html
+++ b/research/current-programs/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/" aria-current="page">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/" aria-current="page">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/research/facilities/index.html
+++ b/research/facilities/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/" aria-current="page">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/" aria-current="page">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/research/funding/index.html
+++ b/research/funding/index.html
@@ -1,0 +1,720 @@
+<!doctype html>
+<html class="no-js" lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Funding — INSTAR Lab</title>
+        <meta name="description" content="INSTAR Lab helps researchers and citizen scientists discover federal funding opportunities and connect with grant-writing support across NSF, NIH, SBIR/STTR, and more.">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="canonical" href="https://instarlab.org/research/funding/">
+        <meta name="robots" content="index, follow">
+        <meta name="theme-color" content="#1072ba">
+
+        <!-- Favicon
+        ============================================ -->
+        <link rel="apple-touch-icon" sizes="180x180" href="../../img/logo/fav/apple-touch-icon.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="../../img/logo/fav/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
+        <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
+
+        <!-- Open Graph
+        ============================================ -->
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="https://instarlab.org/research/funding/">
+        <meta property="og:title" content="Funding — INSTAR Lab">
+        <meta property="og:description" content="INSTAR Lab helps researchers and citizen scientists discover federal funding opportunities and connect with grant-writing support across NSF, NIH, SBIR/STTR, and more.">
+        <meta property="og:image" content="https://instarlab.org/img/og/default.jpg">
+        <meta property="og:image:alt" content="Federal funding discovery for researchers at INSTAR Lab">
+        <meta property="og:site_name" content="INSTAR Lab">
+
+        <!-- Twitter Card
+        ============================================ -->
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:site" content="@INSTARLab">
+        <meta name="twitter:title" content="Funding — INSTAR Lab">
+        <meta name="twitter:description" content="INSTAR Lab helps researchers and citizen scientists discover federal funding opportunities and connect with grant-writing support across NSF, NIH, SBIR/STTR, and more.">
+        <meta name="twitter:image" content="https://instarlab.org/img/og/default.jpg">
+
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "WebPage",
+          "name": "Funding — INSTAR Lab",
+          "description": "INSTAR Lab helps researchers and citizen scientists discover federal funding opportunities and connect with grant-writing support.",
+          "url": "https://instarlab.org/research/funding/",
+          "inLanguage": "en-US",
+          "isPartOf": {
+            "@type": "WebSite",
+            "name": "INSTAR Lab",
+            "url": "https://instarlab.org/"
+          },
+          "about": {
+            "@type": "Thing",
+            "name": "Federal Research Funding and Grant Writing"
+          },
+          "breadcrumb": {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://instarlab.org/" },
+              { "@type": "ListItem", "position": 2, "name": "Research", "item": "https://instarlab.org/research/" },
+              { "@type": "ListItem", "position": 3, "name": "Funding", "item": "https://instarlab.org/research/funding/" }
+            ]
+          }
+        }
+        </script>
+
+        <!-- master CSS
+        ============================================ -->
+        <link rel="stylesheet" href="../../master.css">
+
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+    </head>
+    <body>
+        <a class="skip-to-content" href="#main-content">Skip to main content</a>
+        <!-- Start main area -->
+        <div class="main-area">
+            <!-- Start header -->
+            <header>
+                <!-- Start header top -->
+                <div class="header-top">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-5 col-md-6">
+                                <div class="top-social"></div>
+                            </div>
+                            <div class="col-sm-7 col-md-6">
+                                <!-- NAV-2026-TOPBAR:START -->
+                                <div class="call-to-action">
+                                    <nav aria-label="Contact">
+                                        <ul>
+                                            <li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+                                            <li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+                                            <li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+                                        </ul>
+                                    </nav>
+                                </div>
+                                <!-- NAV-2026-TOPBAR:END -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- End header top -->
+                <!-- NAV-2026:START -->
+                <!-- Start main menu area -->
+                <div class="main-menu-area" id="sticker">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-3 col-12">
+                                <div class="logo ptb-32">
+                                    <a href="../../index.html">
+                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+                                    </a>
+                                </div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+                            </div>
+                            <div class="col-sm-9 col-12">
+                                <div class="donate-button ptb-32">
+                                    <a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+                                </div>
+                                <div class="main-menu">
+                                    <nav aria-label="Main">
+                                        <ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/" aria-current="page">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Earth &amp; Space</li>
+                                                        <li><a href="../../sciences/agriculture/">Agriculture</a></li>
+                                                        <li><a href="../../sciences/geology/">Geology</a></li>
+                                                        <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
+                                                        <li><a href="../../sciences/outer-space/">Outer Space</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Social Sciences</li>
+                                                        <li><a href="../../sciences/anthropology/">Anthropology</a></li>
+                                                        <li><a href="../../sciences/archaeology/">Archaeology</a></li>
+                                                        <li><a href="../../sciences/economics/">Economics</a></li>
+                                                        <li><a href="../../sciences/law/">Law</a></li>
+                                                        <li><a href="../../sciences/linguistics/">Linguistics</a></li>
+                                                        <li><a href="../../sciences/psychology/">Psychology</a></li>
+                                                        <li><a href="../../sciences/sociology/">Sociology</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Life Sciences</li>
+                                                        <li><a href="../../sciences/biology/">Biology</a></li>
+                                                        <li><a href="../../sciences/genetics/">Genetics</a></li>
+                                                        <li><a href="../../sciences/medicine/">Medicine</a></li>
+                                                        <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                                                        <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
+                                                        <li><a href="../../sciences/physiology/">Physiology</a></li>
+                                                        <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
+                                                    </ul>
+                                                    <ul class="single-mega-item">
+                                                        <li class="shortcode-title">Physical Sciences</li>
+                                                        <li><a href="../../sciences/chemistry/">Chemistry</a></li>
+                                                        <li><a href="../../sciences/physics/">Physics</a></li>
+                                                        <li><a href="../../sciences/materials-science/">Materials Science</a></li>
+                                                        <li><a href="../../sciences/energy/">Energy</a></li>
+                                                    </ul>
+                                                </div>
+                                            </li>
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
+                                                    <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
+                                                    <li><a href="../../technology/data-science/">Data Science</a></li>
+                                                    <li><a href="../../technology/computer-science/">Computer Science</a></li>
+                                                    <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                                                    <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                                                    <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 5. Tech Transfer -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
+                                                    <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                                                    <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                                                    <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                                                    <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
+                                                    <li><a href="../../community/fellowship/">Fellowship</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
+                                                    <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+                                        </ul>
+                                    </nav>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- End main menu area -->
+                <!-- Mobile nav backdrop -->
+                <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+                <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+                <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+                    <div class="mobile-nav__header">
+                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                        <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                            <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                                <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                                <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="mobile-nav__body">
+                        <ul class="mobile-nav__list">
+                            <!-- 1. About -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                                    About
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-about">
+                                    <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                                </ul>
+                            </li>
+                            <!-- 2. Research -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                                    Research
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-research">
+                                    <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../research/funding/" aria-current="page">Funding</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                                </ul>
+                            </li>
+                            <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                                    Sciences
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                                    <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                                    <li class="mobile-nav__sub-heading">Social Sciences</li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                                    <li class="mobile-nav__sub-heading">Life Sciences</li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                                    <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                                </ul>
+                            </li>
+                            <!-- 4. Technology -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                                    Technology
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-technology">
+                                    <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                                </ul>
+                            </li>
+                            <!-- 5. Tech Transfer -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                                    Tech Transfer
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                                    <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                                </ul>
+                            </li>
+                            <!-- 6. Community -->
+                            <li class="mobile-nav__item">
+                                <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                                    Community
+                                    <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="mobile-nav__sub" id="mob-sub-community">
+                                    <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                                    <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                                </ul>
+                            </li>
+                            <!-- 7. News -->
+                            <li class="mobile-nav__item">
+                                <a class="mobile-nav__link" href="../../news/">News</a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="mobile-nav__donate">
+                        <a href="../../community/support/">Donate</a>
+                    </div>
+                </nav>
+                <!-- NAV-2026:END -->
+            </header>
+            <!-- End header -->
+
+            <main id="main-content">
+                <!-- Start page title -->
+                <section class="page-title-area">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-12">
+                                <div class="page-title text-center">
+                                    <h1>FUNDING</h1>
+                                </div>
+                                <div class="breadcumb-area text-center">
+                                    <nav aria-label="breadcrumb"><ol class="breadcrumb">
+                                        <li class="breadcrumb-item"><a href="../../index.html">Home</a></li>
+                                        <li class="breadcrumb-item"><a href="#">Research</a></li>
+                                        <li class="breadcrumb-item active" aria-current="page">Funding</li>
+                                    </ol></nav>
+                                </div>
+                                <div class="back-home">
+                                    <a href="../../index.html"><i class="fa fa-arrow-left" aria-hidden="true"></i> BACK TO HOME</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End page title -->
+
+                <!-- Start hero intro -->
+                <section class="ip-hero-intro">
+                    <div class="ip-hero-intro__overlay"></div>
+                    <div class="container">
+                        <div class="ip-hero-intro__content">
+                            <span class="ip-hero-intro__eyebrow">Research</span>
+                            <h2 class="ip-hero-intro__title">Federal Funding Opportunities Matched to Your Science</h2>
+                            <p class="ip-hero-intro__desc">INSTAR Lab helps researchers and citizen scientists discover relevant federal funding — grants, contracts, and SBIR/STTR programs — and connects them with grant-writing resources and support. Our Source Now database aggregates opportunities across more than 50 federal funding sources, filtered by INSTAR's core research domains.</p>
+                        </div>
+                    </div>
+                </section>
+                <!-- End hero intro -->
+
+                <!-- Start intro section -->
+                <section class="ip-section">
+                    <div class="container">
+                        <div class="ip-content-block">
+                            <div class="ip-content-block__text">
+                                <span class="ip-content-block__label"><i class="fa fa-search" aria-hidden="true"></i> Discovery</span>
+                                <h3 class="ip-content-block__heading">Connecting Researchers to Federal Funding</h3>
+                                <p class="ip-content-block__body">Federal research funding is distributed across dozens of agencies — the National Science Foundation, National Institutes of Health, Department of Energy, DARPA, and many others — each with distinct program requirements, review cycles, and eligibility criteria. Navigating that landscape takes time and domain knowledge that researchers and small teams cannot always spare.</p>
+                                <p class="ip-content-block__body">INSTAR Lab's funding discovery resources help researchers and citizen scientists identify opportunities aligned with their work, understand funder requirements, and connect with grant-writing support. Our Source Now database monitors federal opportunity feeds across more than 50 sources and filters them by INSTAR's core research domains — AI, quantum science, energy, health, HPC, and the broader sciences.</p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End intro section -->
+
+                <!-- Start find funding section -->
+                <section class="ip-section ip-section--alt">
+                    <div class="container">
+                        <div class="ip-card-grid__intro">
+                            <h2>FIND <span>FUNDING</span></h2>
+                            <div class="ip-section-title__bar"></div>
+                            <p>The categories below represent the types of federal funding opportunities surfaced through INSTAR's Source Now database. These are illustrative program categories — visit the authoritative federal sources linked below each to explore current open solicitations.</p>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm-6 col-lg-4">
+                                <div class="ip-card">
+                                    <div class="ip-card__body">
+                                        <h3 class="ip-card__title"><span><i class="fa fa-flask" aria-hidden="true"></i> NSF Research Grants</span></h3>
+                                        <p class="ip-card__desc">The National Science Foundation funds fundamental research across all fields of science and engineering. Programs include standard research grants, CAREER awards for early-career investigators, and cross-disciplinary initiatives.</p>
+                                        <p><a href="https://www.nsf.gov/funding/" target="_blank" rel="noopener noreferrer">Explore NSF funding &rarr;</a></p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-4">
+                                <div class="ip-card">
+                                    <div class="ip-card__body">
+                                        <h3 class="ip-card__title"><span><i class="fa fa-heartbeat" aria-hidden="true"></i> NIH Research Grants</span></h3>
+                                        <p class="ip-card__desc">The National Institutes of Health funds biomedical, behavioral, and health sciences research through mechanisms including R01 investigator-initiated grants, R21 exploratory grants, and numerous institute-specific programs.</p>
+                                        <p><a href="https://grants.nih.gov/funding/index.htm" target="_blank" rel="noopener noreferrer">Explore NIH funding &rarr;</a></p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-4">
+                                <div class="ip-card">
+                                    <div class="ip-card__body">
+                                        <h3 class="ip-card__title"><span><i class="fa fa-industry" aria-hidden="true"></i> SBIR / STTR Programs</span></h3>
+                                        <p class="ip-card__desc">Small Business Innovation Research (SBIR) and Small Business Technology Transfer (STTR) programs provide competitive funding for small businesses and research partners to develop and commercialize innovation. INSTAR has direct experience with STTR partnerships.</p>
+                                        <p><a href="https://www.sbir.gov/" target="_blank" rel="noopener noreferrer">Explore SBIR/STTR &rarr;</a></p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-4">
+                                <div class="ip-card">
+                                    <div class="ip-card__body">
+                                        <h3 class="ip-card__title"><span><i class="fa fa-bolt" aria-hidden="true"></i> DOE Research Programs</span></h3>
+                                        <p class="ip-card__desc">The Department of Energy's Office of Science funds research across basic energy sciences, nuclear and high energy physics, advanced computing, and fusion energy — with special vehicles for early-career researchers.</p>
+                                        <p><a href="https://science.osti.gov/grants" target="_blank" rel="noopener noreferrer">Explore DOE funding &rarr;</a></p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-4">
+                                <div class="ip-card">
+                                    <div class="ip-card__body">
+                                        <h3 class="ip-card__title"><span><i class="fa fa-globe" aria-hidden="true"></i> Grants.gov — Federal Search</span></h3>
+                                        <p class="ip-card__desc">Grants.gov is the central repository for all federal grant opportunities. Search by agency, program area, eligibility, and deadline to identify opportunities across the full spectrum of federal funders.</p>
+                                        <p><a href="https://www.grants.gov/search-grants" target="_blank" rel="noopener noreferrer">Search Grants.gov &rarr;</a></p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-4">
+                                <div class="ip-card">
+                                    <div class="ip-card__body">
+                                        <h3 class="ip-card__title"><span><i class="fa fa-rocket" aria-hidden="true"></i> NASA &amp; Defense Programs</span></h3>
+                                        <p class="ip-card__desc">NASA's Space Technology and Science Mission Directorates, DARPA, and the Office of Naval Research fund advanced research at the frontier of aerospace, autonomous systems, sensing, and national security science.</p>
+                                        <p><a href="https://www.nasa.gov/offices/oce/grants/index.html" target="_blank" rel="noopener noreferrer">Explore NASA funding &rarr;</a></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End find funding section -->
+
+                <!-- Start how INSTAR helps -->
+                <section class="ip-section">
+                    <div class="container">
+                        <div class="ip-card-grid__intro">
+                            <h2>HOW INSTAR <span>HELPS</span></h2>
+                            <div class="ip-section-title__bar"></div>
+                            <p>Beyond discovery, INSTAR provides guidance and resources to help researchers prepare competitive proposals and manage funded awards.</p>
+                        </div>
+                        <div class="help-us-content-area row">
+                            <div class="col-sm-4">
+                                <div class="single-help">
+                                    <div class="help-icon">
+                                        <i class="fa fa-file-text-o" aria-hidden="true"></i>
+                                    </div>
+                                    <div class="help-text">
+                                        <h3>Grant Writing Guidance</h3>
+                                        <p>Structuring a competitive proposal — from the Specific Aims page through the Research Strategy — requires domain knowledge and strategic clarity. INSTAR connects researchers with guidance resources and review support to strengthen proposals before submission.</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-4">
+                                <div class="single-help">
+                                    <div class="help-icon">
+                                        <i class="fa fa-sitemap" aria-hidden="true"></i>
+                                    </div>
+                                    <div class="help-text">
+                                        <h3>Funder Landscape</h3>
+                                        <p>Understanding which federal agencies fund which types of research — and how their review criteria differ — is essential to targeting the right opportunity. INSTAR's resources map the landscape by research domain so investigators can direct their efforts efficiently.</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-4">
+                                <div class="single-help">
+                                    <div class="help-icon">
+                                        <i class="fa fa-check-square-o" aria-hidden="true"></i>
+                                    </div>
+                                    <div class="help-text">
+                                        <h3>Compliance &amp; Management</h3>
+                                        <p>Managing a funded award — reporting requirements, budget management, and regulatory compliance — is a distinct discipline. INSTAR's grant management resources help researchers fulfill award obligations and stay focused on the science.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row" style="margin-top:30px;">
+                            <div class="col-sm-12 text-center">
+                                <p>Authoritative federal grant resources: <a href="https://www.grants.gov" target="_blank" rel="noopener noreferrer">Grants.gov</a> &bull; <a href="https://grants.nih.gov" target="_blank" rel="noopener noreferrer">NIH Grants</a> &bull; <a href="https://www.nsf.gov/funding/" target="_blank" rel="noopener noreferrer">NSF Funding</a> &bull; <a href="https://www.sbir.gov" target="_blank" rel="noopener noreferrer">SBIR.gov</a></p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End how INSTAR helps -->
+
+                <!-- Start Dream Maker CTA band -->
+                <section class="ip-cta-band ip-cta-band--warm">
+                    <div class="container">
+                        <p class="ip-cta-band__eyebrow">Grant Writing &amp; Management</p>
+                        <h2 class="ip-cta-band__heading">Write &amp; Manage Your Grant with Dream Maker</h2>
+                        <p class="ip-cta-band__body">INSTAR's Dream Maker program provides a structured environment for writing and managing grant proposals — from initial Specific Aims through budget submission and award management. Dream Maker is available to INSTAR researchers and Consortium fellows. Contact us to learn how to access it.</p>
+                        <div class="ip-cta-band__actions">
+                            <a href="../../community/contact/" class="ip-cta-band__btn ip-cta-band__btn--primary">
+                                <i class="fa fa-envelope" aria-hidden="true"></i>&nbsp; Contact Us About Dream Maker
+                            </a>
+                            <a href="../../tech-transfer/sttr-programs/" class="ip-cta-band__btn ip-cta-band__btn--outline-blue">
+                                <i class="fa fa-industry" aria-hidden="true"></i>&nbsp; SBIR / STTR Programs
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <!-- End Dream Maker CTA band -->
+
+                <!-- Start stats area -->
+                <section class="ip-stats">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-3 col-6">
+                                <div class="ip-stat">
+                                    <div class="ip-stat__icon"><i class="fa fa-database" aria-hidden="true"></i></div>
+                                    <div class="ip-stat__number">50+</div>
+                                    <div class="ip-stat__label">Federal Sources Monitored</div>
+                                </div>
+                            </div>
+                            <div class="col-sm-3 col-6">
+                                <div class="ip-stat">
+                                    <div class="ip-stat__icon"><i class="fa fa-flask" aria-hidden="true"></i></div>
+                                    <div class="ip-stat__number">NSF</div>
+                                    <div class="ip-stat__label">National Science Foundation</div>
+                                </div>
+                            </div>
+                            <div class="col-sm-3 col-6">
+                                <div class="ip-stat">
+                                    <div class="ip-stat__icon"><i class="fa fa-heartbeat" aria-hidden="true"></i></div>
+                                    <div class="ip-stat__number">NIH</div>
+                                    <div class="ip-stat__label">National Institutes of Health</div>
+                                </div>
+                            </div>
+                            <div class="col-sm-3 col-6">
+                                <div class="ip-stat">
+                                    <div class="ip-stat__icon"><i class="fa fa-industry" aria-hidden="true"></i></div>
+                                    <div class="ip-stat__number">SBIR</div>
+                                    <div class="ip-stat__label">Small Business Innovation Research</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- End stats area -->
+            </main>
+
+            <!-- Start footer -->
+            <footer>
+                <div class="footer-top pt-50 pb-50">
+                    <div class="container">
+                        <div class="row">
+                            <div class="footer-widget-area row">
+                                <div class="col-sm-4">
+                                    <div class="footer-widget widget-one">
+                                        <div class="footer-widget-title">
+                                            <h3>ABOUT US</h3>
+                                        </div>
+                                        <div class="widget-about-content">
+                                            <p>INSTAR Lab is an independent 501(c)(3) nonprofit research institute advancing science through interdisciplinary collaboration, technological innovation, and partnership.</p>
+                                        </div>
+                                        <div class="widget-contact-content">
+                                            <h3>CONTACT US</h3>
+                                            <a href="tel:+18552214692">Phone: +1 855-221-4692</a>
+                                            <a href="mailto:info@instarlab.org">Email: info@instarlab.org</a>
+                                            <a href="https://maps.google.com/?q=125+Frederick+St+Marietta+OH+45750">Address: 125 Frederick St, Marietta, OH 45750</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2">
+                                    <div class="footer-widget widget-two">
+                                        <div class="footer-widget-title">
+                                            <h3>RESEARCH</h3>
+                                        </div>
+                                        <nav>
+                                            <ul>
+                                                <li><a href="../../research/innovation/">Innovation</a></li>
+                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                <li><a href="../../research/facilities/">Facilities</a></li>
+                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                <li><a href="../../research/consortium/">Consortium</a></li>
+                                            </ul>
+                                        </nav>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2">
+                                    <div class="footer-widget widget-two">
+                                        <div class="footer-widget-title">
+                                            <h3>QUICK LINKS</h3>
+                                        </div>
+                                        <nav>
+                                            <ul>
+                                                <li><a href="../../community/about-us/">About Us</a></li>
+                                                <li><a href="../../community/careers/">Careers</a></li>
+                                                <li><a href="../../community/contact/">Contact</a></li>
+                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
+                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                                            </ul>
+                                        </nav>
+                                    </div>
+                                </div>
+                                <div class="col-sm-4">
+                                    <div class="footer-widget widget-four">
+                                        <div class="footer-widget-title">
+                                            <h3>NEWSLETTER</h3>
+                                        </div>
+                                        <div class="widget-about-content">
+                                            <p>Stay updated with INSTAR research news and events.</p>
+                                        </div>
+                                        <div class="newslater">
+                                            <form id="mc-form" class="mc-form form">
+                                                <input id="mc-email" type="email" autocomplete="off" placeholder="Email Address" aria-label="Email address for newsletter">
+                                                <button id="mc-submit" type="submit" aria-label="Subscribe to newsletter"><i class="fa fa-envelope" aria-hidden="true"></i></button>
+                                            </form>
+                                            <div class="mailchimp-alerts text-center">
+                                                <div class="mailchimp-submitting"></div>
+                                                <div class="mailchimp-success"></div>
+                                                <div class="mailchimp-error"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="footer-bottom">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-8">
+                                <div class="copyright">
+                                    <p>INSTAR Lab Inc. is a registered 501(c)(3) nonprofit. Copyright &copy; 2026 INSTAR Lab Inc. All Rights Reserved.</p>
+                                </div>
+                            </div>
+                            <div class="col-sm-4">
+                                <div class="footer-social"></div>
+                            </div>
+                        </div>
+                        <div class="d-none d-sm-block" id="back-top" aria-label="Back to top" role="button" tabindex="0"></div>
+                    </div>
+                </div>
+            </footer>
+            <!-- End footer -->
+        </div>
+        <!-- End main area -->
+
+        <script src="../../js/vendor/jquery-1.12.0.min.js"></script>
+        <script src="../../js/bootstrap.min.js"></script>
+        <script src="../../js/owl.carousel.min.js"></script>
+        <script src="../../js/jquery.nivo.slider.pack.js"></script>
+        <script src="../../js/jquery.mixitup.min.js"></script>
+        <script src="../../js/jquery.magnific-popup.min.js"></script>
+        <script src="../../js/jquery.meanmenu.js"></script>
+        <script src="../../js/wow.js"></script>
+        <script src="../../js/jquery.scrollUp.min.js"></script>
+        <script src="../../js/jquery.ajaxchimp.min.js"></script>
+        <script src="../../js/plugins.js"></script>
+        <script>new WOW().init();</script>
+        <script src="../../js/styleswitch.js"></script>
+        <script src="../../js/main.js"></script>
+    </body>
+</html>

--- a/research/innovation/index.html
+++ b/research/innovation/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/" aria-current="page">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/" aria-current="page">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/research/open-data/index.html
+++ b/research/open-data/index.html
@@ -64,8 +64,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!-- Start main area -->
@@ -80,37 +84,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/" aria-current="page">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -147,132 +192,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/" aria-current="page">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/research/opportunities/index.html
+++ b/research/opportunities/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/" aria-current="page">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/" aria-current="page">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/research/our-process/index.html
+++ b/research/our-process/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/" aria-current="page">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/" aria-current="page">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/agriculture/index.html
+++ b/sciences/agriculture/index.html
@@ -75,8 +75,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -91,41 +95,81 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
-                                                        <li><a href="../../sciences/agriculture/">Agriculture</a></li>
+                                                        <li><a href="../../sciences/agriculture/" aria-current="page">Agriculture</a></li>
                                                         <li><a href="../../sciences/geology/">Geology</a></li>
                                                         <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
                                                         <li><a href="../../sciences/outer-space/">Outer Space</a></li>
@@ -159,132 +203,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/" aria-current="page">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/anthropology/index.html
+++ b/sciences/anthropology/index.html
@@ -75,8 +75,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -91,38 +95,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -132,7 +176,7 @@
                                                     </ul>
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Social Sciences</li>
-                                                        <li><a href="../../sciences/anthropology/">Anthropology</a></li>
+                                                        <li><a href="../../sciences/anthropology/" aria-current="page">Anthropology</a></li>
                                                         <li><a href="../../sciences/archaeology/">Archaeology</a></li>
                                                         <li><a href="../../sciences/economics/">Economics</a></li>
                                                         <li><a href="../../sciences/law/">Law</a></li>
@@ -159,132 +203,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/" aria-current="page">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/archaeology/index.html
+++ b/sciences/archaeology/index.html
@@ -75,8 +75,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -91,38 +95,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -133,7 +177,7 @@
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Social Sciences</li>
                                                         <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                        <li><a href="../../sciences/archaeology/">Archaeology</a></li>
+                                                        <li><a href="../../sciences/archaeology/" aria-current="page">Archaeology</a></li>
                                                         <li><a href="../../sciences/economics/">Economics</a></li>
                                                         <li><a href="../../sciences/law/">Law</a></li>
                                                         <li><a href="../../sciences/linguistics/">Linguistics</a></li>
@@ -159,132 +203,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/" aria-current="page">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/biology/index.html
+++ b/sciences/biology/index.html
@@ -77,8 +77,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -93,38 +97,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -144,7 +188,7 @@
                                                     </ul>
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Life Sciences</li>
-                                                        <li><a href="../../sciences/biology/">Biology</a></li>
+                                                        <li><a href="../../sciences/biology/" aria-current="page">Biology</a></li>
                                                         <li><a href="../../sciences/genetics/">Genetics</a></li>
                                                         <li><a href="../../sciences/medicine/">Medicine</a></li>
                                                         <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
@@ -161,132 +205,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/" aria-current="page">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/chemistry/index.html
+++ b/sciences/chemistry/index.html
@@ -77,8 +77,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -93,38 +97,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -154,139 +198,188 @@
                                                     </ul>
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Physical Sciences</li>
-                                                        <li><a href="../../sciences/chemistry/">Chemistry</a></li>
+                                                        <li><a href="../../sciences/chemistry/" aria-current="page">Chemistry</a></li>
                                                         <li><a href="../../sciences/physics/">Physics</a></li>
                                                         <li><a href="../../sciences/materials-science/">Materials Science</a></li>
                                                         <li><a href="../../sciences/energy/">Energy</a></li>
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/" aria-current="page">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/cognitive-sciences/index.html
+++ b/sciences/cognitive-sciences/index.html
@@ -77,8 +77,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -93,38 +97,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -147,7 +191,7 @@
                                                         <li><a href="../../sciences/biology/">Biology</a></li>
                                                         <li><a href="../../sciences/genetics/">Genetics</a></li>
                                                         <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                        <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                                                        <li><a href="../../sciences/cognitive-sciences/" aria-current="page">Cognitive Sciences</a></li>
                                                         <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
                                                         <li><a href="../../sciences/physiology/">Physiology</a></li>
                                                         <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
@@ -161,132 +205,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/" aria-current="page">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/economics/index.html
+++ b/sciences/economics/index.html
@@ -77,8 +77,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -93,38 +97,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -136,7 +180,7 @@
                                                         <li class="shortcode-title">Social Sciences</li>
                                                         <li><a href="../../sciences/anthropology/">Anthropology</a></li>
                                                         <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                        <li><a href="../../sciences/economics/">Economics</a></li>
+                                                        <li><a href="../../sciences/economics/" aria-current="page">Economics</a></li>
                                                         <li><a href="../../sciences/law/">Law</a></li>
                                                         <li><a href="../../sciences/linguistics/">Linguistics</a></li>
                                                         <li><a href="../../sciences/psychology/">Psychology</a></li>
@@ -161,132 +205,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/" aria-current="page">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/energy/index.html
+++ b/sciences/energy/index.html
@@ -77,8 +77,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -93,38 +97,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -157,136 +201,185 @@
                                                         <li><a href="../../sciences/chemistry/">Chemistry</a></li>
                                                         <li><a href="../../sciences/physics/">Physics</a></li>
                                                         <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                        <li><a href="../../sciences/energy/">Energy</a></li>
+                                                        <li><a href="../../sciences/energy/" aria-current="page">Energy</a></li>
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/" aria-current="page">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/genetics/index.html
+++ b/sciences/genetics/index.html
@@ -77,8 +77,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -93,38 +97,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -145,7 +189,7 @@
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Life Sciences</li>
                                                         <li><a href="../../sciences/biology/">Biology</a></li>
-                                                        <li><a href="../../sciences/genetics/">Genetics</a></li>
+                                                        <li><a href="../../sciences/genetics/" aria-current="page">Genetics</a></li>
                                                         <li><a href="../../sciences/medicine/">Medicine</a></li>
                                                         <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
                                                         <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
@@ -161,132 +205,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/" aria-current="page">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/geology/index.html
+++ b/sciences/geology/index.html
@@ -76,8 +76,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -92,42 +96,82 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                        <li><a href="../../sciences/geology/">Geology</a></li>
+                                                        <li><a href="../../sciences/geology/" aria-current="page">Geology</a></li>
                                                         <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
                                                         <li><a href="../../sciences/outer-space/">Outer Space</a></li>
                                                     </ul>
@@ -160,132 +204,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/" aria-current="page">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/kinesiology/index.html
+++ b/sciences/kinesiology/index.html
@@ -76,8 +76,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -92,38 +96,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -149,7 +193,7 @@
                                                         <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
                                                         <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
                                                         <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                        <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
+                                                        <li><a href="../../sciences/kinesiology/" aria-current="page">Kinesiology</a></li>
                                                     </ul>
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Physical Sciences</li>
@@ -160,132 +204,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/" aria-current="page">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/law/index.html
+++ b/sciences/law/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -126,7 +170,7 @@
                                                         <li><a href="../../sciences/anthropology/">Anthropology</a></li>
                                                         <li><a href="../../sciences/archaeology/">Archaeology</a></li>
                                                         <li><a href="../../sciences/economics/">Economics</a></li>
-                                                        <li><a href="../../sciences/law/">Law</a></li>
+                                                        <li><a href="../../sciences/law/" aria-current="page">Law</a></li>
                                                         <li><a href="../../sciences/linguistics/">Linguistics</a></li>
                                                         <li><a href="../../sciences/psychology/">Psychology</a></li>
                                                         <li><a href="../../sciences/sociology/">Sociology</a></li>
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/" aria-current="page">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/linguistics/index.html
+++ b/sciences/linguistics/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -127,7 +171,7 @@
                                                         <li><a href="../../sciences/archaeology/">Archaeology</a></li>
                                                         <li><a href="../../sciences/economics/">Economics</a></li>
                                                         <li><a href="../../sciences/law/">Law</a></li>
-                                                        <li><a href="../../sciences/linguistics/">Linguistics</a></li>
+                                                        <li><a href="../../sciences/linguistics/" aria-current="page">Linguistics</a></li>
                                                         <li><a href="../../sciences/psychology/">Psychology</a></li>
                                                         <li><a href="../../sciences/sociology/">Sociology</a></li>
                                                     </ul>
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/" aria-current="page">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/materials-science/index.html
+++ b/sciences/materials-science/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -145,137 +189,186 @@
                                                         <li class="shortcode-title">Physical Sciences</li>
                                                         <li><a href="../../sciences/chemistry/">Chemistry</a></li>
                                                         <li><a href="../../sciences/physics/">Physics</a></li>
-                                                        <li><a href="../../sciences/materials-science/">Materials Science</a></li>
+                                                        <li><a href="../../sciences/materials-science/" aria-current="page">Materials Science</a></li>
                                                         <li><a href="../../sciences/energy/">Energy</a></li>
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/" aria-current="page">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/medicine/index.html
+++ b/sciences/medicine/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -135,7 +179,7 @@
                                                         <li class="shortcode-title">Life Sciences</li>
                                                         <li><a href="../../sciences/biology/">Biology</a></li>
                                                         <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                        <li><a href="../../sciences/medicine/">Medicine</a></li>
+                                                        <li><a href="../../sciences/medicine/" aria-current="page">Medicine</a></li>
                                                         <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
                                                         <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
                                                         <li><a href="../../sciences/physiology/">Physiology</a></li>
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/" aria-current="page">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/neuroscience/index.html
+++ b/sciences/neuroscience/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -137,7 +181,7 @@
                                                         <li><a href="../../sciences/genetics/">Genetics</a></li>
                                                         <li><a href="../../sciences/medicine/">Medicine</a></li>
                                                         <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                        <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
+                                                        <li><a href="../../sciences/neuroscience/" aria-current="page">Neuroscience</a></li>
                                                         <li><a href="../../sciences/physiology/">Physiology</a></li>
                                                         <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
                                                     </ul>
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/" aria-current="page">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/ocean-science/index.html
+++ b/sciences/ocean-science/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,43 +86,83 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
                                                         <li><a href="../../sciences/geology/">Geology</a></li>
-                                                        <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
+                                                        <li><a href="../../sciences/ocean-science/" aria-current="page">Ocean Science</a></li>
                                                         <li><a href="../../sciences/outer-space/">Outer Space</a></li>
                                                     </ul>
                                                     <ul class="single-mega-item">
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/" aria-current="page">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/outer-space/index.html
+++ b/sciences/outer-space/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,44 +86,84 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
                                                         <li><a href="../../sciences/geology/">Geology</a></li>
                                                         <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                        <li><a href="../../sciences/outer-space/">Outer Space</a></li>
+                                                        <li><a href="../../sciences/outer-space/" aria-current="page">Outer Space</a></li>
                                                     </ul>
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Social Sciences</li>
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/" aria-current="page">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/physics/index.html
+++ b/sciences/physics/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -144,138 +188,187 @@
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Physical Sciences</li>
                                                         <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                        <li><a href="../../sciences/physics/">Physics</a></li>
+                                                        <li><a href="../../sciences/physics/" aria-current="page">Physics</a></li>
                                                         <li><a href="../../sciences/materials-science/">Materials Science</a></li>
                                                         <li><a href="../../sciences/energy/">Energy</a></li>
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/" aria-current="page">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/physiology/index.html
+++ b/sciences/physiology/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -138,7 +182,7 @@
                                                         <li><a href="../../sciences/medicine/">Medicine</a></li>
                                                         <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
                                                         <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                        <li><a href="../../sciences/physiology/">Physiology</a></li>
+                                                        <li><a href="../../sciences/physiology/" aria-current="page">Physiology</a></li>
                                                         <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
                                                     </ul>
                                                     <ul class="single-mega-item">
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/" aria-current="page">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/psychology/index.html
+++ b/sciences/psychology/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -128,7 +172,7 @@
                                                         <li><a href="../../sciences/economics/">Economics</a></li>
                                                         <li><a href="../../sciences/law/">Law</a></li>
                                                         <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                        <li><a href="../../sciences/psychology/">Psychology</a></li>
+                                                        <li><a href="../../sciences/psychology/" aria-current="page">Psychology</a></li>
                                                         <li><a href="../../sciences/sociology/">Sociology</a></li>
                                                     </ul>
                                                     <ul class="single-mega-item">
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/" aria-current="page">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sciences/sociology/index.html
+++ b/sciences/sociology/index.html
@@ -66,8 +66,12 @@
         </script>
 
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -82,38 +86,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#" aria-current="page">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -129,7 +173,7 @@
                                                         <li><a href="../../sciences/law/">Law</a></li>
                                                         <li><a href="../../sciences/linguistics/">Linguistics</a></li>
                                                         <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                        <li><a href="../../sciences/sociology/">Sociology</a></li>
+                                                        <li><a href="../../sciences/sociology/" aria-current="page">Sociology</a></li>
                                                     </ul>
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Life Sciences</li>
@@ -150,132 +194,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/" aria-current="page">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,6 +18,7 @@
   <url><loc>https://instarlab.org/research/consortium/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://instarlab.org/research/facilities/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://instarlab.org/research/opportunities/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://instarlab.org/research/funding/</loc><lastmod>2026-06-25</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://instarlab.org/research/open-data/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://instarlab.org/sciences/agriculture/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://instarlab.org/sciences/anthropology/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
@@ -55,6 +56,7 @@
   <url><loc>https://instarlab.org/labs/sovereign-ai/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://instarlab.org/labs/biometric-security/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://instarlab.org/labs/cognitive-ai/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://instarlab.org/news/</loc><lastmod>2026-06-25</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://instarlab.org/news/quantum-sensing-breakthroughs/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://instarlab.org/news/hpc-infrastructure-for-ai/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://instarlab.org/news/clinical-ai-safety/</loc><lastmod>2026-06-16</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>

--- a/tech-transfer/enterprise-rd/index.html
+++ b/tech-transfer/enterprise-rd/index.html
@@ -46,8 +46,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -62,38 +66,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -130,132 +174,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                    <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                                                    <li><a href="../../tech-transfer/enterprise-rd/" aria-current="page">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/" aria-current="page">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/tech-transfer/portfolio/index.html
+++ b/tech-transfer/portfolio/index.html
@@ -46,8 +46,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -62,38 +66,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -130,132 +174,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                    <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                                                    <li><a href="../../tech-transfer/portfolio/" aria-current="page">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/" aria-current="page">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/tech-transfer/sttr-programs/index.html
+++ b/tech-transfer/sttr-programs/index.html
@@ -46,8 +46,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -62,38 +66,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -130,132 +174,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Tech Transfer</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
+                                                    <li><a href="../../tech-transfer/sttr-programs/" aria-current="page">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/" aria-current="page">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/tech-transfer/workshops-events/index.html
+++ b/tech-transfer/workshops-events/index.html
@@ -46,8 +46,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -62,38 +66,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -130,132 +174,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#" aria-current="page">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                    <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                                                    <li><a href="../../tech-transfer/workshops-events/" aria-current="page">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/" aria-current="page">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/technology/augmented-reality/index.html
+++ b/technology/augmented-reality/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#" aria-current="page">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                    <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                                                    <li><a href="../../technology/augmented-reality/" aria-current="page">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/" aria-current="page">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/technology/computer-science/index.html
+++ b/technology/computer-science/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#" aria-current="page">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                    <li><a href="../../technology/computer-science/">Computer Science</a></li>
+                                                    <li><a href="../../technology/computer-science/" aria-current="page">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/" aria-current="page">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/technology/data-science/index.html
+++ b/technology/data-science/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#" aria-current="page">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                    <li><a href="../../technology/data-science/">Data Science</a></li>
+                                                    <li><a href="../../technology/data-science/" aria-current="page">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/" aria-current="page">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/technology/formal-methods/index.html
+++ b/technology/formal-methods/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#" aria-current="page">Technology</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
+                                                    <li><a href="../../technology/formal-methods/" aria-current="page">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/" aria-current="page">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/technology/machine-intelligence/index.html
+++ b/technology/machine-intelligence/index.html
@@ -78,8 +78,12 @@
         }
         </script>
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -94,38 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -162,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#" aria-current="page">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                    <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/machine-intelligence/" aria-current="page">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/" aria-current="page">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/technology/natural-language-processing/index.html
+++ b/technology/natural-language-processing/index.html
@@ -61,8 +61,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -77,38 +81,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-    						<div class="main-menu">
-    							<nav>
-    								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -145,132 +189,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#" aria-current="page">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/" aria-current="page">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-    									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-    								</ul>
-    							</nav>
-    						</div>
-    						<div class="donate-button ptb-32">
-    							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-    						</div>
-    					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/" aria-current="page">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/technology/quantum-computing/index.html
+++ b/technology/quantum-computing/index.html
@@ -61,8 +61,12 @@
         <link rel="icon" type="image/png" sizes="16x16" href="../../img/logo/fav/favicon-16x16.png">
         <link rel="manifest" href="../../img/logo/fav/site.webmanifest">
         <link rel="stylesheet" href="../../master.css">
-        <script src="../../js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="../../css/nav-2026.css">
+        <script defer src="../../js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
 		<!-- Start main area -->
@@ -77,38 +81,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="../../about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a>
-                                            </li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="../../research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="../../index.html">
-                                        <img src="../../img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-        						<div class="main-menu">
-        							<nav>
-        								<ul>
-                                            <li  class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="../../index.html">
+								<img src="../../img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="../../community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="../../mission.html">Mission</a></li>
+                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                                    <li><a href="../../community/leadership/">Leadership</a></li>
+                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="../../research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="../../research/innovation/">Innovation</a></li>
+                                                    <li><a href="../../research/our-process/">Our Process</a></li>
+                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="../../research/funding/">Funding</a></li>
+                                                    <li><a href="../../research/open-data/">Open Data</a></li>
+                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="../../sciences/agriculture/">Agriculture</a></li>
@@ -145,132 +189,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#" aria-current="page">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="../../technology/data-science/">Data Science</a></li>
                                                     <li><a href="../../technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                    <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
+                                                    <li><a href="../../technology/quantum-computing/" aria-current="page">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-        									<li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../research/innovation/">Innovation</a></li>
-                                                    <li><a href="../../research/our-process/">Our Process</a></li>
-                                                    <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="../../research/facilities/">Facilities</a></li>
-                                                    <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="../../community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="../../community/contact/">Contact</a></li>
+                                                    <li><a href="../../community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="../../community/careers/">Careers</a></li>
+                                                    <li><a href="../../community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-        								</ul>
-        							</nav>
-        						</div>
-        						<div class="donate-button ptb-32">
-        							<a class="waves-effect waves-light" href="../../community/contact/">Donate</a>
-        						</div>
-        					</div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="../../index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="../../sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="../../sciences/geology/">Geology</a></li>
-                                                <li><a href="../../sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="../../sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="../../sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="../../sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="../../sciences/economics/">Economics</a></li>
-                                                <li><a href="../../sciences/law/">Law</a></li>
-                                                <li><a href="../../sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="../../sciences/psychology/">Psychology</a></li>
-                                                <li><a href="../../sciences/sociology/">Sociology</a></li>
-                                                <li><a href="../../sciences/biology/">Biology</a></li>
-                                                <li><a href="../../sciences/genetics/">Genetics</a></li>
-                                                <li><a href="../../sciences/medicine/">Medicine</a></li>
-                                                <li><a href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="../../sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="../../sciences/physiology/">Physiology</a></li>
-                                                <li><a href="../../sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="../../sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="../../sciences/physics/">Physics</a></li>
-                                                <li><a href="../../sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="../../sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="../../technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="../../technology/data-science/">Data Science</a></li>
-                                                <li><a href="../../technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="../../technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="../../technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="../../tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="../../research/innovation/">Innovation</a></li>
-                                                <li><a href="../../research/our-process/">Our Process</a></li>
-                                                <li><a href="../../research/current-programs/">Current Programs</a></li>
-                                                <li><a href="../../research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="../../research/facilities/">Facilities</a></li>
-                                                <li><a href="../../research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="../../community/about-us/">About Us</a></li>
-                                                <li><a href="../../community/fellowship/">Fellowship</a></li>
-                                                <li><a href="../../community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="../../community/contact/">Contact</a></li>
-                                                <li><a href="../../community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="../../news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="../../img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="../../mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="../../research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="../../technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../technology/quantum-computing/" aria-current="page">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="../../community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="../../community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="../../news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="../../community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">

--- a/terms.html
+++ b/terms.html
@@ -1,10 +1,4 @@
 <!doctype html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]> <html lang="en" class="ie6">    <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7">    <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8">    <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8">
@@ -80,9 +74,12 @@
 
         <!-- master CSS -->
         <link rel="stylesheet" href="master.css">
-
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-    </head>
+        <!-- NAV-2026-HEAD:START -->
+        <script>document.documentElement.classList.replace('no-js','js');</script>
+        <link rel="stylesheet" href="css/nav-2026.css">
+        <script defer src="js/nav-2026.js"></script>
+        <!-- NAV-2026-HEAD:END -->
+</head>
     <body>
         <a class="skip-to-content" href="#main-content">Skip to main content</a>
         <!--[if lt IE 8]>
@@ -101,37 +98,78 @@
                                 <div class="top-social"></div>
                             </div>
                             <div class="col-sm-7 col-md-6">
-                                <div class="call-to-action">
-                                    <nav>
-                                        <ul>
-                                            <li><a href="mailto:info@instarlab.org"><i class="fa fa-envelope" aria-hidden="true"></i> Email: info@instarlab.org</a></li>
-                                            <li><a href="tel:+18552214692"><i class="fa fa-phone" aria-hidden="true"></i> Phone: +1 855-221-4692</a></li>
-                                            <li><a href="about.html"><i class="fa fa-flask" aria-hidden="true"></i> Research</a></li>
-                                        </ul>
-                                    </nav>
-                                </div>
+                                	                            <!-- NAV-2026-TOPBAR:START -->
+                            <div class="call-to-action">
+                                <nav aria-label="Contact">
+                                	<ul>
+	                                	<li><a href="mailto:info@instarlab.org"><svg width="14" height="11" viewBox="0 0 14 11" aria-hidden="true" focusable="false"><rect x="1" y="1" width="12" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><polyline points="1,1.5 7,6.5 13,1.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg> Email: info@instarlab.org</a></li>
+	                                	<li><a href="tel:+18552214692"><svg width="12" height="13" viewBox="0 0 12 13" aria-hidden="true" focusable="false"><path d="M2.5 1.5h2.2l.9 2.6-1.7 1.2c.8 1.8 2.2 3.1 3.9 3.9L9.1 7.6l2.6.9v2.2a1 1 0 0 1-1 1C4.2 11.7.3 7.8.3 2.5a1 1 0 0 1 1-1h1.2z" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linejoin="round"/></svg> Phone: +1 855-221-4692</a></li>
+	                                	<li><a href="research/current-programs/"><svg width="12" height="14" viewBox="0 0 12 14" aria-hidden="true" focusable="false"><path d="M4.5 1v5.5L1.5 12h9L7.5 6.5V1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round" stroke-linejoin="round"/><line x1="3" y1="1" x2="9" y2="1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Research</a></li>
+	                                </ul>
+                                </nav>
                             </div>
+                            <!-- NAV-2026-TOPBAR:END -->
                         </div>
                     </div>
                 </div>
                 <!-- End header top -->
-                <!-- Start main menu area -->
-                <div class="main-menu-area" id="sticker">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="logo ptb-32">
-                                    <a href="index.html">
-                                        <img src="img/logo/instar.svg" alt="INSTAR Lab">
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="col-sm-9 col-12">
-                                <div class="main-menu">
-                                    <nav>
-                                        <ul>
-                                            <li class="mega-menu"><a href="#">Sciences</a>
-                                                <div class="mega-menu-area">
+                        		<!-- NAV-2026:START -->
+		<!-- Start main menu area -->
+		<div class="main-menu-area" id="sticker">
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-3 col-12">
+						<div class="logo ptb-32">
+							<a href="index.html">
+								<img src="img/logo/instar.svg" alt="INSTAR Lab">
+							</a>
+						</div>
+                                <!-- Hamburger: visible on mobile ≤991px only -->
+                                <button type="button" class="mobile-menu-btn"
+                                        aria-expanded="false"
+                                        aria-controls="mobile-nav"
+                                        aria-label="Open navigation menu">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line class="hb-line hb-top" x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-mid" x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                        <line class="hb-line hb-bot" x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                    </svg>
+                                </button>
+					</div>
+					<div class="col-sm-9 col-12">
+						<div class="donate-button ptb-32">
+							<a class="waves-effect waves-light" href="community/support/">Donate</a>
+						</div>
+						<div class="main-menu">
+							<nav aria-label="Main">
+								<ul>
+                                            <!-- 1. About -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-about">About <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-about">
+                                                    <li><a href="mission.html">Mission</a></li>
+                                                    <li><a href="community/about-us/">About Us</a></li>
+                                                    <li><a href="community/leadership/">Leadership</a></li>
+                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
+                                                    <li><a href="research/facilities/">Facilities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 2. Research -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-research">Research <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-research">
+                                                    <li><a href="research/innovation/">Innovation</a></li>
+                                                    <li><a href="research/our-process/">Our Process</a></li>
+                                                    <li><a href="research/current-programs/">Current Programs</a></li>
+                                                    <li><a href="research/funding/">Funding</a></li>
+                                                    <li><a href="research/open-data/">Open Data</a></li>
+                                                    <li><a href="research/opportunities/">Opportunities</a></li>
+                                                </ul>
+                                            </li>
+                                            <!-- 3. Sciences — 4-column mega-menu -->
+                                            <li class="mega-menu">
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-sciences">Sciences <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <div class="mega-menu-area" id="submenu-sciences">
                                                     <ul class="single-mega-item">
                                                         <li class="shortcode-title">Earth &amp; Space</li>
                                                         <li><a href="sciences/agriculture/">Agriculture</a></li>
@@ -168,132 +206,181 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><a href="#">Technology</a>
-                                                <ul class="drop-menu">
+                                            <!-- 4. Technology -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-technology">Technology <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-technology">
                                                     <li><a href="technology/formal-methods/">Formal Methods</a></li>
                                                     <li><a href="technology/data-science/">Data Science</a></li>
                                                     <li><a href="technology/computer-science/">Computer Science</a></li>
                                                     <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                                                    <li><a href="technology/natural-language-processing/">Natural Language Processing</a></li>
                                                     <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
                                                     <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Tech Transfer</a>
-                                                <ul class="drop-menu">
+                                            <!-- 5. Tech Transfer -->
+									<li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-tech-transfer">Tech Transfer <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-tech-transfer">
                                                     <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
                                                     <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
                                                     <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
                                                     <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
                                                 </ul>
                                             </li>
-                                            <li><a href="#">Research</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="research/innovation/">Innovation</a></li>
-                                                    <li><a href="research/our-process/">Our Process</a></li>
-                                                    <li><a href="research/current-programs/">Current Programs</a></li>
-                                                    <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                    <li><a href="research/facilities/">Facilities</a></li>
-                                                    <li><a href="research/opportunities/">Opportunities</a></li>
-                                                </ul>
-                                            </li>
-                                            <li><a href="#">Community</a>
-                                                <ul class="drop-menu">
-                                                    <li><a href="community/about-us/">About Us</a></li>
+                                            <!-- 6. Community -->
+                                            <li>
+                                                <button type="button" class="nav-toggle" aria-expanded="false" aria-haspopup="true" aria-controls="submenu-community">Community <svg class="nav-chevron" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true" focusable="false"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                                <ul class="drop-menu" id="submenu-community">
                                                     <li><a href="community/fellowship/">Fellowship</a></li>
-                                                    <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                    <li><a href="community/contact/">Contact</a></li>
+                                                    <li><a href="community/work-with-us/">Collaborate</a></li>
                                                     <li><a href="community/careers/">Careers</a></li>
+                                                    <li><a href="community/contact/">Contact</a></li>
                                                 </ul>
                                             </li>
-                                        </ul>
-                                    </nav>
-                                </div>
-                                <div class="donate-button ptb-32">
-                                    <a class="waves-effect waves-light" href="community/contact/">Donate</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End main menu area -->
-                <!-- Start mobile menu -->
-                <div class="mobile-menu-area">
-                    <div class="container">
-                        <div class="row">
-                            <div class="mobile-menu">
-                                <nav id="dropdown">
-                                    <ul class="nav">
-                                        <li><a href="index.html">Home</a></li>
-                                        <li><a href="#">Sciences</a>
-                                            <ul>
-                                                <li><a href="sciences/agriculture/">Agriculture</a></li>
-                                                <li><a href="sciences/geology/">Geology</a></li>
-                                                <li><a href="sciences/ocean-science/">Ocean Science</a></li>
-                                                <li><a href="sciences/outer-space/">Outer Space</a></li>
-                                                <li><a href="sciences/anthropology/">Anthropology</a></li>
-                                                <li><a href="sciences/archaeology/">Archaeology</a></li>
-                                                <li><a href="sciences/economics/">Economics</a></li>
-                                                <li><a href="sciences/law/">Law</a></li>
-                                                <li><a href="sciences/linguistics/">Linguistics</a></li>
-                                                <li><a href="sciences/psychology/">Psychology</a></li>
-                                                <li><a href="sciences/sociology/">Sociology</a></li>
-                                                <li><a href="sciences/biology/">Biology</a></li>
-                                                <li><a href="sciences/genetics/">Genetics</a></li>
-                                                <li><a href="sciences/medicine/">Medicine</a></li>
-                                                <li><a href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
-                                                <li><a href="sciences/neuroscience/">Neuroscience</a></li>
-                                                <li><a href="sciences/physiology/">Physiology</a></li>
-                                                <li><a href="sciences/kinesiology/">Kinesiology</a></li>
-                                                <li><a href="sciences/chemistry/">Chemistry</a></li>
-                                                <li><a href="sciences/physics/">Physics</a></li>
-                                                <li><a href="sciences/materials-science/">Materials Science</a></li>
-                                                <li><a href="sciences/energy/">Energy</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Technology</a>
-                                            <ul>
-                                                <li><a href="technology/formal-methods/">Formal Methods</a></li>
-                                                <li><a href="technology/data-science/">Data Science</a></li>
-                                                <li><a href="technology/computer-science/">Computer Science</a></li>
-                                                <li><a href="technology/machine-intelligence/">Machine Intelligence</a></li>
-                                                <li><a href="technology/augmented-reality/">Augmented Reality</a></li>
-                                                <li><a href="technology/quantum-computing/">Quantum Computing</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Tech Transfer</a>
-                                            <ul>
-                                                <li><a href="tech-transfer/sttr-programs/">STTR Programs</a></li>
-                                                <li><a href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
-                                                <li><a href="tech-transfer/portfolio/">Portfolio</a></li>
-                                                <li><a href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Research</a>
-                                            <ul>
-                                                <li><a href="research/innovation/">Innovation</a></li>
-                                                <li><a href="research/our-process/">Our Process</a></li>
-                                                <li><a href="research/current-programs/">Current Programs</a></li>
-                                                <li><a href="research/consortium/">INSTAR Consortium</a></li>
-                                                <li><a href="research/facilities/">Facilities</a></li>
-                                                <li><a href="research/opportunities/">Opportunities</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">Community</a>
-                                            <ul>
-                                                <li><a href="community/about-us/">About Us</a></li>
-                                                <li><a href="community/fellowship/">Fellowship</a></li>
-                                                <li><a href="community/work-with-us/">Work With Us</a></li>
-                                                <li><a href="community/contact/">Contact</a></li>
-                                                <li><a href="community/careers/">Careers</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End mobile menu -->
+                                            <!-- 7. News (direct link) -->
+                                            <li><a class="nav-link" href="news/">News</a></li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- End main menu area -->
+        <!-- Mobile nav backdrop -->
+        <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true"></div>
+        <!-- Mobile nav off-canvas drawer (vanilla JS, no meanmenu) -->
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+            <div class="mobile-nav__header">
+                <img src="img/logo/instar.svg" alt="INSTAR Lab" class="mobile-nav__logo">
+                <button type="button" class="mobile-nav__close" aria-label="Close navigation menu">
+                    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="none">
+                        <line x1="3" y1="3" x2="17" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                        <line x1="17" y1="3" x2="3" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="mobile-nav__body">
+                <ul class="mobile-nav__list">
+                    <!-- 1. About -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-about">
+                            About
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-about">
+                            <li><a class="mobile-nav__sub-link" href="mission.html">Mission</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/about-us/">About Us</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/leadership/">Leadership</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/consortium/">INSTAR Consortium</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/facilities/">Facilities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 2. Research -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-research">
+                            Research
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-research">
+                            <li><a class="mobile-nav__sub-link" href="research/innovation/">Innovation</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/our-process/">Our Process</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/current-programs/">Current Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/funding/">Funding</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/open-data/">Open Data</a></li>
+                            <li><a class="mobile-nav__sub-link" href="research/opportunities/">Opportunities</a></li>
+                        </ul>
+                    </li>
+                    <!-- 3. Sciences (mega-menu flattened with category headings) -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-sciences">
+                            Sciences
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-sciences">
+                            <li class="mobile-nav__sub-heading">Earth &amp; Space</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/agriculture/">Agriculture</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/geology/">Geology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/ocean-science/">Ocean Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/outer-space/">Outer Space</a></li>
+                            <li class="mobile-nav__sub-heading">Social Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/anthropology/">Anthropology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/archaeology/">Archaeology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/economics/">Economics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/law/">Law</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/linguistics/">Linguistics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/psychology/">Psychology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/sociology/">Sociology</a></li>
+                            <li class="mobile-nav__sub-heading">Life Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/biology/">Biology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/genetics/">Genetics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/medicine/">Medicine</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/cognitive-sciences/">Cognitive Sciences</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/neuroscience/">Neuroscience</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physiology/">Physiology</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/kinesiology/">Kinesiology</a></li>
+                            <li class="mobile-nav__sub-heading">Physical Sciences</li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/chemistry/">Chemistry</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/physics/">Physics</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/materials-science/">Materials Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="sciences/energy/">Energy</a></li>
+                        </ul>
+                    </li>
+                    <!-- 4. Technology -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-technology">
+                            Technology
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-technology">
+                            <li><a class="mobile-nav__sub-link" href="technology/formal-methods/">Formal Methods</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/data-science/">Data Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/computer-science/">Computer Science</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/machine-intelligence/">Machine Intelligence</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/natural-language-processing/">Natural Language Processing</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/augmented-reality/">Augmented Reality</a></li>
+                            <li><a class="mobile-nav__sub-link" href="technology/quantum-computing/">Quantum Computing</a></li>
+                        </ul>
+                    </li>
+                    <!-- 5. Tech Transfer -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-tech-transfer">
+                            Tech Transfer
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-tech-transfer">
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/sttr-programs/">STTR Programs</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/enterprise-rd/">Enterprise R&amp;D</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/portfolio/">Portfolio</a></li>
+                            <li><a class="mobile-nav__sub-link" href="tech-transfer/workshops-events/">Workshops &amp; Events</a></li>
+                        </ul>
+                    </li>
+                    <!-- 6. Community -->
+                    <li class="mobile-nav__item">
+                        <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mob-sub-community">
+                            Community
+                            <svg class="mobile-nav__chevron" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" fill="none"><path d="M3 6l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                        <ul class="mobile-nav__sub" id="mob-sub-community">
+                            <li><a class="mobile-nav__sub-link" href="community/fellowship/">Fellowship</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/work-with-us/">Collaborate</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/careers/">Careers</a></li>
+                            <li><a class="mobile-nav__sub-link" href="community/contact/">Contact</a></li>
+                        </ul>
+                    </li>
+                    <!-- 7. News -->
+                    <li class="mobile-nav__item">
+                        <a class="mobile-nav__link" href="news/">News</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="mobile-nav__donate">
+                <a href="community/support/">Donate</a>
+            </div>
+        </nav>
+        <!-- NAV-2026:END -->
             </header>
             <!-- End header -->
             <main id="main-content">


### PR DESCRIPTION
## Summary
Replaces the legacy Charitykit hover-only navigation with a WCAG 2.2 AA, 2026-standard disclosure nav across the entire site (63 pages), and adds the two new pages the restructured nav links to.

**Information architecture** (approved): `About · Research · Sciences · Technology · Tech Transfer · Community · News`
- New top-level **About** and **News** (closes credibility gaps every peer research institute carries).
- **Funding** lives as a child under Research (not top-level) — peer-consistent, avoids audience dilution. Source Now discovery feed + Dream Maker write/manage hand-off.
- "Work With Us" → **"Collaborate"** (removes the Careers collision).
- Donate button now points to `community/support/` (was `community/contact/` — conversion fix).

**Accessibility / standards**
- Hover-only menus → keyboard-operable `<button>` disclosure pattern (W3C APG): `aria-expanded`/`aria-haspopup`/`aria-controls`, Esc-to-close + focus return, `:focus-visible` rings, one-open-at-a-time.
- New **vanilla off-canvas mobile drawer** (focus trap, scroll-lock, backdrop, accordion submenus) — drops jQuery/meanmenu dependency for nav.
- Removed Modernizr 2.8.3 + IE conditional comments. Nav icons → inline SVG (kills the FontAwesome glyph-bbox console warnings).
- Fixed a pre-existing mega-menu positioning bug site-wide (was rendering off-screen due to missing positioning context).
- Shared `css/nav-2026.css` + `js/nav-2026.js` (no more per-page hand-edits; nav defined once).

**New pages**
- `research/funding/` — Source Now-powered discovery framing + authoritative external links + Dream Maker CTA. No fabricated figures.
- `news/` — landing reusing the 3 real existing articles.
- `sitemap.xml` updated.

## Test plan
- Playwright headless verification at desktop (1366px) and mobile (390px) across depth-0/1/2 pages + both new pages: 6 disclosure toggles, correct-depth CSS/JS resolution, Sciences mega-menu opens via keyboard, mobile drawer opens, **0 console errors, 0 network failures** on every page.
- Propagation verified: 0 `id="dropdown"` / `modernizr` / old-topbar stragglers; no raster image refs introduced (AVIF-only); exactly one nav-2026.css link per page at correct depth; `aria-current` on 46 pages' active links.
- Redirect stub `community/fellowship/` correctly skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)